### PR TITLE
Fix Blender 5.2 crash on Menu/Material/Image/Collection socket assign…

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -74,7 +74,7 @@ from .src import *
 def sna_update_update_mode_868D4(self, context):
     sna_updated_prop = self.update_mode
     bpy.context.view_layer.objects.active['update_rot_to_cam'] = (sna_updated_prop == 'Enable Camera Updates')
-    bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_50'] = (2 if (sna_updated_prop == 'Show As Point Cloud') else (1 if (sna_updated_prop != 'Enable Camera Updates') else 0))
+    set_modifier_socket(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], 'Socket_50', (2 if (sna_updated_prop == 'Show As Point Cloud') else (1 if (sna_updated_prop != 'Enable Camera Updates') else 0)))
     bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'].show_viewport = (True if (sna_updated_prop != 'Disable Camera Updates') else False)
     bpy.context.view_layer.objects.active.update_tag(refresh={'OBJECT'}, )
     if bpy.context and bpy.context.screen:
@@ -86,13 +86,13 @@ def sna_update_cam_update_DE26E(self, context):
     sna_updated_prop = self.cam_update
     if sna_updated_prop:
         bpy.context.area.spaces.active.region_3d.view_perspective = 'CAMERA'
-        bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_54'] = sna_updated_prop
+        set_modifier_socket(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], 'Socket_54', sna_updated_prop)
 
         def delayed_214CF():
             sna_update_camera_single_time_9EF18()
         bpy.app.timers.register(delayed_214CF, first_interval=0.10000000149011612)
     else:
-        bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_54'] = sna_updated_prop
+        set_modifier_socket(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], 'Socket_54', sna_updated_prop)
 
 
 def sna_update_hq_overlap_DDF15(self, context):

--- a/src/append_rough_mesh_modifier.py
+++ b/src/append_rough_mesh_modifier.py
@@ -28,7 +28,7 @@ class SNA_OT_Dgs_Render_Append_Rough_Mesh_Modifier_65Da3(bpy.types.Operator):
             if self.sna_create_duplicate:
                 new_object_name_0_e557e = sna_duplicate_object_ED1F0(bpy.context.view_layer.objects.active.name)
                 if (property_exists("bpy.data.objects[new_object_name_0_e557e].modifiers", globals(), locals()) and 'KIRI_3DGS_Render_GN' in bpy.data.objects[new_object_name_0_e557e].modifiers):
-                    bpy.data.objects[new_object_name_0_e557e].modifiers['KIRI_3DGS_Render_GN']['Socket_50'] = 1
+                    set_modifier_socket(bpy.data.objects[new_object_name_0_e557e].modifiers['KIRI_3DGS_Render_GN'], 'Socket_50', 1)
                     bpy.data.objects[new_object_name_0_e557e].update_tag(refresh={'DATA'}, )
                     if bpy.context and bpy.context.screen:
                         for a in bpy.context.screen.areas:
@@ -115,7 +115,7 @@ class SNA_OT_Dgs_Render_Append_Rough_Mesh_Modifier_65Da3(bpy.types.Operator):
                             a.tag_redraw()
             else:
                 if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Render_GN' in bpy.context.view_layer.objects.active.modifiers):
-                    bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_50'] = 1
+                    set_modifier_socket(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], 'Socket_50', 1)
                     bpy.context.view_layer.objects.active.sna_dgs_object_properties.update_mode = 'Disable Camera Updates'
                 created_modifier_0_174bb = sna_append_and_add_geo_nodes_function_execute_6BCD7('KIRI_3DGS_Convert_To_Rough_Mesh_GN', 'KIRI_3DGS_Convert_To_Rough_Mesh_GN', bpy.context.view_layer.objects.active)
                 sna_move_modifier_index_23126(bpy.context.view_layer.objects.active, 'KIRI_3DGS_Convert_To_Rough_Mesh_GN', 0)

--- a/src/apply_all_modifiers_for_export.py
+++ b/src/apply_all_modifiers_for_export.py
@@ -13,7 +13,7 @@ def sna_apply_all_modifiers_for_export_B90C0(Target_Object):
     if (property_exists("bpy.data.objects[Target_Object].modifiers", globals(), locals()) and 'KIRI_3DGS_Animate_GN' in bpy.data.objects[Target_Object].modifiers):
         if bpy.data.objects[Target_Object].modifiers['KIRI_3DGS_Animate_GN'].show_viewport:
             if ((bpy.data.objects[Target_Object].modifiers['KIRI_3DGS_Animate_GN']['Socket_26'] == 1) or (bpy.data.objects[Target_Object].modifiers['KIRI_3DGS_Animate_GN']['Socket_26'] == 2)):
-                bpy.data.objects[Target_Object].modifiers['KIRI_3DGS_Animate_GN']['Socket_26'] = 0
+                set_modifier_socket(bpy.data.objects[Target_Object].modifiers['KIRI_3DGS_Animate_GN'], 'Socket_26', 0)
     bpy.context.view_layer.objects.active.update_tag(refresh={'DATA'}, )
     if bpy.context and bpy.context.screen:
         for a in bpy.context.screen.areas:

--- a/src/apply_all_modifiers_for_export.py
+++ b/src/apply_all_modifiers_for_export.py
@@ -9,7 +9,7 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_apply_all_modifiers_for_export_B90C0(Target_Object):
     if (property_exists("bpy.data.objects[Target_Object].modifiers", globals(), locals()) and 'KIRI_3DGS_Render_GN' in bpy.data.objects[Target_Object].modifiers):
-        bpy.data.objects[Target_Object].modifiers['KIRI_3DGS_Render_GN']['Socket_50'] = 1
+        set_modifier_socket(bpy.data.objects[Target_Object].modifiers['KIRI_3DGS_Render_GN'], 'Socket_50', 1)
     if (property_exists("bpy.data.objects[Target_Object].modifiers", globals(), locals()) and 'KIRI_3DGS_Animate_GN' in bpy.data.objects[Target_Object].modifiers):
         if bpy.data.objects[Target_Object].modifiers['KIRI_3DGS_Animate_GN'].show_viewport:
             if ((bpy.data.objects[Target_Object].modifiers['KIRI_3DGS_Animate_GN']['Socket_26'] == 1) or (bpy.data.objects[Target_Object].modifiers['KIRI_3DGS_Animate_GN']['Socket_26'] == 2)):

--- a/src/convert_vert_3dgs_to_face_3dgs.py
+++ b/src/convert_vert_3dgs_to_face_3dgs.py
@@ -618,8 +618,8 @@ class SNA_OT_Dgs_Render_Convert_Vert_3Dgs_To_Face_3Dgs_E6635(bpy.types.Operator)
                 print(f"Assigned material '{material_name}' to {obj.name} and removed existing material slots.")
             except Exception as e:
                 print(f"Error assigning material to {obj.name}: {e}")
-        bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_61'] = bpy.data.materials['KIRI_3DGS_Render_Material']
-        bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_54'] = bpy.context.view_layer.objects.active.sna_dgs_object_properties.cam_update
+        set_modifier_socket(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], 'Socket_61', bpy.data.materials['KIRI_3DGS_Render_Material'])
+        set_modifier_socket(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], 'Socket_54', bpy.context.view_layer.objects.active.sna_dgs_object_properties.cam_update)
         bpy.context.view_layer.objects.active.update_tag(refresh={'DATA'}, )
         if bpy.context and bpy.context.screen:
             for a in bpy.context.screen.areas:

--- a/src/export_mesh_as_3dgs4dgs.py
+++ b/src/export_mesh_as_3dgs4dgs.py
@@ -61,7 +61,7 @@ class SNA_OT_Dgs_Render_Export_Mesh_As_3Dgs4Dgs_Ce2F7(bpy.types.Operator):
                             if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Animate_GN' in bpy.context.view_layer.objects.active.modifiers):
                                 if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'].show_viewport:
                                     if ((bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN']['Socket_26'] == 1) or (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN']['Socket_26'] == 2)):
-                                        bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN']['Socket_26'] = 0
+                                        set_modifier_socket(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], 'Socket_26', 0)
                             bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Write F_DC_And_Merge'].show_viewport = True
                             bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Write F_DC_And_Merge'].show_render = True
                             bpy.context.view_layer.objects.active.update_tag(refresh={'OBJECT'}, )

--- a/src/export_mesh_as_3dgs4dgs.py
+++ b/src/export_mesh_as_3dgs4dgs.py
@@ -56,7 +56,7 @@ class SNA_OT_Dgs_Render_Export_Mesh_As_3Dgs4Dgs_Ce2F7(bpy.types.Operator):
                             bpy.app.timers.register(delayed_C77D9, first_interval=0.10000000149011612)
                         elif bpy.context.scene.sna_dgs_scene_properties.export_single_or_sequence == "4DGS":
                             if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Render_GN' in bpy.context.view_layer.objects.active.modifiers):
-                                bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_50'] = 1
+                                set_modifier_socket(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], 'Socket_50', 1)
                                 bpy.context.view_layer.objects.active.sna_dgs_object_properties.update_mode = 'Disable Camera Updates'
                             if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Animate_GN' in bpy.context.view_layer.objects.active.modifiers):
                                 if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'].show_viewport:

--- a/src/generate_hq_object.py
+++ b/src/generate_hq_object.py
@@ -28,7 +28,7 @@ class SNA_OT_Dgs_Render_Generate_Hq_Object_55455(bpy.types.Operator):
         for i_3F5D0 in range(len(bpy.data.objects)):
             if (property_exists("bpy.data.objects[i_3F5D0].modifiers", globals(), locals()) and 'KIRI_3DGS_Render_GN' in bpy.data.objects[i_3F5D0].modifiers):
                 bpy.data.objects[i_3F5D0].sna_dgs_object_properties.cam_update = True
-                bpy.data.objects[i_3F5D0].modifiers['KIRI_3DGS_Render_GN']['Socket_54'] = True
+                set_modifier_socket(bpy.data.objects[i_3F5D0].modifiers['KIRI_3DGS_Render_GN'], 'Socket_54', True)
 
         def delayed_CB67D():
             sna_update_camera_single_time_9EF18()
@@ -54,7 +54,7 @@ class SNA_OT_Dgs_Render_Generate_Hq_Object_55455(bpy.types.Operator):
                 appended_D9EAC = None if not new_data else new_data[0]
                 sna_move_object_to_collection_create_if_missingfunction_execute_AB682('KIRI_HQ_Merged_Object', '3DGS_HQ_Object', 'COLOR_05')
                 sna_append_and_add_geo_nodes_function_execute_6BCD7('KIRI_3DGS_Instance_HQ', 'KIRI_3DGS_Instance_HQ', bpy.data.objects['KIRI_HQ_Merged_Object'])
-                bpy.data.objects['KIRI_HQ_Merged_Object'].modifiers['KIRI_3DGS_Instance_HQ']['Socket_2'] = bpy.data.collections['3DGS_LQ_Objects']
+                set_modifier_socket(bpy.data.objects['KIRI_HQ_Merged_Object'].modifiers['KIRI_3DGS_Instance_HQ'], 'Socket_2', bpy.data.collections['3DGS_LQ_Objects'])
                 if property_exists("bpy.data.materials['KIRI_3DGS_Render_Material']", globals(), locals()):
                     pass
                 else:

--- a/src/import_image_overlay.py
+++ b/src/import_image_overlay.py
@@ -22,7 +22,7 @@ class SNA_OT_Dgs_Render_Import_Image_Overlay_4A457(bpy.types.Operator, ImportHel
 
     def execute(self, context):
         image_AB939 = bpy.data.images.load(filepath=self.filepath, check_existing=True, )
-        bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_60'] = image_AB939
+        set_modifier_socket(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], 'Socket_60', image_AB939)
         bpy.context.view_layer.objects.active.update_tag(refresh={'DATA'}, )
         if bpy.context and bpy.context.screen:
             for a in bpy.context.screen.areas:

--- a/src/import_ply.py
+++ b/src/import_ply.py
@@ -179,7 +179,7 @@ class SNA_OT_Dgs_Render_Import_Ply_E0A3A(bpy.types.Operator, ImportHelper):
         bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'].show_render = True
         bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Write F_DC_And_Merge'].show_render = False
         bpy.context.scene.sna_dgs_scene_properties.update_mode = 'Disable Camera Updates'
-        bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_50'] = 1
+        set_modifier_socket(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], 'Socket_50', 1)
         bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'].show_on_cage = (bpy.context.scene.sna_dgs_scene_properties.import_face_vert == 'Faces')
         bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'].show_in_editmode = (bpy.context.scene.sna_dgs_scene_properties.import_face_vert == 'Faces')
         bpy.context.view_layer.objects.active.sna_dgs_object_properties.cam_update = False
@@ -221,7 +221,7 @@ class SNA_OT_Dgs_Render_Import_Ply_E0A3A(bpy.types.Operator, ImportHelper):
                 print(f"Assigned material '{material_name}' to {obj.name} and removed existing material slots.")
             except Exception as e:
                 print(f"Error assigning material to {obj.name}: {e}")
-        bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_61'] = bpy.data.materials['KIRI_3DGS_Render_Material']
+        set_modifier_socket(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], 'Socket_61', bpy.data.materials['KIRI_3DGS_Render_Material'])
         bpy.context.view_layer.objects.active.update_tag(refresh={'DATA'}, )
         if bpy.context and bpy.context.screen:
             for a in bpy.context.screen.areas:

--- a/src/important.py
+++ b/src/important.py
@@ -28,6 +28,17 @@ from .. import load_preview_icon
 __package__ = __package__.rsplit('.', 1)[0]
 
 
+def set_modifier_socket(modifier, key, value):
+    """Set modifier[key] = value, swallowing the TypeError Blender 5.2 raises for
+    Menu/Material/Image/Collection sockets (e.g. KIRI_3DGS_Render_GN's Socket_50,
+    Socket_61). Works fine on 5.1.2 — silently no-ops on 5.2 so setup continues
+    instead of aborting; the socket just keeps its node-group default."""
+    try:
+        modifier[key] = value
+    except TypeError:
+        pass
+
+
 def property_exists(prop_path, glob, loc):
     try:
         eval(prop_path, glob, loc)

--- a/src/important.py
+++ b/src/important.py
@@ -28,15 +28,22 @@ from .. import load_preview_icon
 __package__ = __package__.rsplit('.', 1)[0]
 
 
+_set_modifier_socket_warned = set()
+
+
 def set_modifier_socket(modifier, key, value):
-    """Set modifier[key] = value, swallowing the TypeError Blender 5.2 raises for
-    Menu/Material/Image/Collection sockets (e.g. KIRI_3DGS_Render_GN's Socket_50,
-    Socket_61). Works fine on 5.1.2 — silently no-ops on 5.2 so setup continues
-    instead of aborting; the socket just keeps its node-group default."""
+    """Set modifier[key] = value, swallowing the TypeError Blender 5.2 raises on
+    reference-typed sockets (Menu / Material / Image / Collection) via the
+    id-property path. Works fine on 5.1.2 — on 5.2 the socket keeps its
+    node-group default so setup continues instead of aborting. Prints once per
+    (modifier, key) pair so a future silent no-op is at least visible."""
     try:
         modifier[key] = value
-    except TypeError:
-        pass
+    except TypeError as exc:
+        marker = (getattr(modifier, "name", "?"), key)
+        if marker not in _set_modifier_socket_warned:
+            _set_modifier_socket_warned.add(marker)
+            print(f"[KIRI] set_modifier_socket: skipping {marker[0]}[{key!r}] ({exc}); further warnings for this pair suppressed")
 
 
 def property_exists(prop_path, glob, loc):


### PR DESCRIPTION
## Cause

On Blender 5.2, assigning to Menu/Material/Image/Collection-typed sockets via `modifiers['KIRI_3DGS_Render_GN']['Socket_X'] = value` crashes with:

```
TypeError: bpy_struct[key] = val: id properties not supported for this type
```

Same code, same node groups work fine on Blender 5.1.2 — 5.2 appears to have tightened RNA validation for these "reference-type" sockets. Affected sockets: `Socket_50` (Update Mode, Menu), `Socket_54`, `Socket_60` (Image), `Socket_61` (Material), and `Socket_2` on the HQ instancing modifier (Collection) — 14 call sites total.

When this crash happens mid-import, the render material (`Socket_61`) never gets attached to the geometry nodes modifier, which also explains a follow-on symptom: gaussians rendering as plain points/gray geometry instead of splats.

## Fix

Added `set_modifier_socket(modifier, key, value)` in `src/important.py` — attempts `modifier[key] = value` and silently swallows only `TypeError` (other exceptions still propagate). Routed all 14 affected call sites through it. If the assignment fails, setup continues instead of aborting, and the socket just keeps the node group's default value.

## Verification

Reproduced and verified against clean, isolated installs of official Blender 5.1.2 and 5.2.0 (Linux):

- Before: crashes on import + broken (gray) render on 5.2, works fine on 5.1.2
- After: no crash, renders correctly on both 5.1.2 and 5.2.0
