### PR TITLE
Fix depth sorting not updating when the view turns in place

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -199,13 +199,13 @@ def sna_update_active_mode_86E6B(self, context):
                 sna_c2_refresh_all_4D367(True, bpy.context.scene.sna_dgs_scene_properties.r2_transforms, True)
                 sna_shader_system_A4AED()
                 sna_texture_creation_FD1B2()
-                sna_viewport_render_A3941(bpy.context.scene.sna_dgs_scene_properties.r2_sh_degree, bpy.context.scene.sna_dgs_scene_properties.r2_sort_threshold)
+                sna_viewport_render_A3941(bpy.context.scene.sna_dgs_scene_properties.r2_sh_degree, bpy.context.scene.sna_dgs_scene_properties.r2_sort_threshold, bpy.context.scene.sna_dgs_scene_properties.rt_rotation_sort_threshold)
             elif bpy.context.scene.sna_dgs_scene_properties.r2_render_rig_cache_mode == "Enabled Baked":
                 sna_rig_5_apply_baked_cache_5656F('All Bound', None)
                 sna_clean_up_scene_5F1F1(False)
                 sna_shader_system_A4AED()
                 sna_texture_creation_FD1B2()
-                sna_viewport_render_A3941(bpy.context.scene.sna_dgs_scene_properties.r2_sh_degree, bpy.context.scene.sna_dgs_scene_properties.r2_sort_threshold)
+                sna_viewport_render_A3941(bpy.context.scene.sna_dgs_scene_properties.r2_sh_degree, bpy.context.scene.sna_dgs_scene_properties.r2_sort_threshold, bpy.context.scene.sna_dgs_scene_properties.rt_rotation_sort_threshold)
             else:
                 pass
     elif sna_updated_prop == "Mesh 2 3DGS":
@@ -259,6 +259,7 @@ class SNA_GROUP_sna_dgs_scene_properties_group(bpy.types.PropertyGroup):
     r2_render_rig_cache_mode: bpy.props.EnumProperty(name='R2_Render_Rig_Cache_Mode', description='', items=[('None', 'None', '', 0, 0), ('Enabled Baked', 'Enabled Baked', '', 0, 1)])
     r2_sh_degree: bpy.props.IntProperty(name='R2_SH_Degree', description='', default=3, subtype='NONE', min=0, max=3)
     r2_sort_threshold: bpy.props.FloatProperty(name='R2_Sort_Threshold', description='', default=0.05000000074505806, subtype='NONE', unit='NONE', min=0.0, max=1.0, step=3, precision=2)
+    rt_rotation_sort_threshold: bpy.props.FloatProperty(name='RT_Rotation_Sort_Threshold', description='How far the view direction must change before the splats are re-sorted by depth. Lower values re-sort more often', default=0.02, subtype='NONE', unit='NONE', min=0.0, max=1.0, step=1, precision=3)
     r2_relight: bpy.props.BoolProperty(name='Relight', description='Evaluate up to 16 enabled Sun, Point, Spot and Area lights in the Gaussian renderer', default=False)
     r2_relight_mode: bpy.props.EnumProperty(name='Relight_Mode', items=[('1', 'Multiply SH', 'Preserve learned appearance and modulate it with new light'), ('2', 'DC Albedo', 'Use DC color as approximate diffuse albedo')], default='1')
     r2_relight_response: bpy.props.EnumProperty(name='Relight_Response', items=[('3', 'Captured', 'Relight by visibility without inferred normals'), ('0', 'Solid', 'One-sided inferred Gaussian normals'), ('1', 'Thin', 'Controlled rear-light transmission'), ('2', 'Two-Sided', 'Two-sided inferred Gaussian normals')], default='3')

--- a/src/clean_up_scene_5f1f1.py
+++ b/src/clean_up_scene_5f1f1.py
@@ -101,6 +101,7 @@ def sna_clean_up_scene_5F1F1(REMOVE_ALL_GAUSSIAN_OBJECTS):
                 'gaussian_last_viewport_visibility', # Per-object viewport visibility tracking
                 # Camera tracking  
                 'gaussian_last_camera_pos',        # Camera position for depth sorting
+                'gaussian_last_view_dir',          # Camera view direction for depth sorting
                 # Update flags
                 'gaussian_global_needs_update',    # Global data update flag
             ]

--- a/src/create_proxy_from_mesh.py
+++ b/src/create_proxy_from_mesh.py
@@ -28,7 +28,7 @@ class SNA_OT_Dgs_Render_Create_Proxy_From_Mesh_Eafbb(bpy.types.Operator):
         sna_b2_load_from_blender_object_F0CCB(bpy.context.view_layer.objects.active.name + 'Splat_Proxy')
         sna_shader_system_A4AED()
         sna_texture_creation_FD1B2()
-        sna_viewport_render_A3941(bpy.context.scene.sna_dgs_scene_properties.r2_sh_degree, bpy.context.scene.sna_dgs_scene_properties.r2_sort_threshold)
+        sna_viewport_render_A3941(bpy.context.scene.sna_dgs_scene_properties.r2_sh_degree, bpy.context.scene.sna_dgs_scene_properties.r2_sort_threshold, bpy.context.scene.sna_dgs_scene_properties.rt_rotation_sort_threshold)
         return {"FINISHED"}
 
     def invoke(self, context, event):

--- a/src/r2_update_menu.py
+++ b/src/r2_update_menu.py
@@ -65,6 +65,7 @@ def sna_r2_update_menu_6A492(layout_function, ):
     col_9BE62.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_9BE62.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_sh_degree', text='SH Degrees', icon_value=0, emboss=True, expand=True)
     col_9BE62.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_sort_threshold', text='Camera Move Sort Threshold', icon_value=0, emboss=True, expand=True)
+    col_9BE62.prop(bpy.context.scene.sna_dgs_scene_properties, 'rt_rotation_sort_threshold', text='Camera Turn Sort Threshold', icon_value=0, emboss=True, expand=True)
     box_4B521 = box_EB86E.box()
     box_4B521.alert = False
     box_4B521.enabled = (not ((bpy.context.scene.sna_dgs_scene_properties.r2_update_type == 'Interval') and (not bpy.context.scene.sna_dgs_scene_properties.r2_interval_stop)))

--- a/src/r2_viewport_update.py
+++ b/src/r2_viewport_update.py
@@ -19,10 +19,10 @@ def sna_r2_viewport_update_BA246():
         sna_clean_up_scene_5F1F1(False)
         sna_shader_system_A4AED()
         sna_texture_creation_FD1B2()
-        sna_viewport_render_A3941(bpy.context.scene.sna_dgs_scene_properties.r2_sh_degree, bpy.context.scene.sna_dgs_scene_properties.r2_sort_threshold)
+        sna_viewport_render_A3941(bpy.context.scene.sna_dgs_scene_properties.r2_sh_degree, bpy.context.scene.sna_dgs_scene_properties.r2_sort_threshold, bpy.context.scene.sna_dgs_scene_properties.rt_rotation_sort_threshold)
     else:
         pass
     sna_c2_refresh_all_4D367((not bpy.context.scene.sna_dgs_scene_properties.r2_selected), bpy.context.scene.sna_dgs_scene_properties.r2_transforms, True)
     sna_shader_system_A4AED()
     sna_texture_creation_FD1B2()
-    sna_viewport_render_A3941(bpy.context.scene.sna_dgs_scene_properties.r2_sh_degree, bpy.context.scene.sna_dgs_scene_properties.r2_sort_threshold)
+    sna_viewport_render_A3941(bpy.context.scene.sna_dgs_scene_properties.r2_sh_degree, bpy.context.scene.sna_dgs_scene_properties.r2_sort_threshold, bpy.context.scene.sna_dgs_scene_properties.rt_rotation_sort_threshold)

--- a/src/viewport_render.py
+++ b/src/viewport_render.py
@@ -9,14 +9,16 @@ from .texture_creation import sna_texture_creation_FD1B2
 __package__ = __package__.rsplit('.', 1)[0]
 
 
-def sna_viewport_render_A3941(SH_DEGREE, SORT_THRESHOLD):
+def sna_viewport_render_A3941(SH_DEGREE, SORT_THRESHOLD, ROTATION_THRESHOLD):
     SH_DEGREE = SH_DEGREE
     SORT_THRESHOLD = SORT_THRESHOLD
+    ROTATION_THRESHOLD = ROTATION_THRESHOLD
     # ========== VARIABLES (EDIT THESE) ==========
     ENABLE_RENDERING = True
     RENDER_MODE = 0  # 0=Gaussian, 1=Depth, 2=Surfel
     #SH_DEGREE = 3    # 0, 1, 2, or 3
-    #SORT_THRESHOLD = 0.05  # Camera movement threshold for re-sorting
+    #SORT_THRESHOLD = 0.05  # Camera movement threshold (kept for compatibility, no longer gates sorting)
+    #ROTATION_THRESHOLD = 0.02  # View direction change threshold for re-sorting
     # ============================================
     #import bpy
     #import gpu
@@ -199,16 +201,22 @@ def sna_viewport_render_A3941(SH_DEGREE, SORT_THRESHOLD):
                 camera_world_matrix.translation.y,
                 camera_world_matrix.translation.z,
             ]
+            # Depth of a splat is (r . p) + d, where r is row 2 of the view matrix
+            # and d is the same constant for every splat. Camera translation only
+            # shifts every depth by that constant, so it cannot change the sort
+            # order -- only a change of view direction can. Track the direction.
+            current_camera_dir = [view_matrix[2][0], view_matrix[2][1], view_matrix[2][2]]
             # NEW: Check if forced depth sort is requested by script_3
             force_sort = getattr(bpy, 'gaussian_needs_depth_sort', False)
-            # Check if camera moved enough to require re-sorting
+            # Check if the view rotated enough to require re-sorting
             update_needed = force_sort  # Start with force flag
-            if not force_sort and hasattr(bpy, 'gaussian_last_camera_pos'):
-                last_pos = bpy.gaussian_last_camera_pos
-                movement = sum((a-b)**2 for a,b in zip(last_pos, current_camera_pos))**0.5
-                update_needed = movement > SORT_THRESHOLD
-            elif not force_sort:
-                update_needed = True  # First time, no stored camera position
+            if not force_sort:
+                last_dir = getattr(bpy, 'gaussian_last_view_dir', None)
+                if last_dir is None:
+                    update_needed = True  # First time, no stored view direction
+                else:
+                    turn = sum((a-b)**2 for a,b in zip(last_dir, current_camera_dir))**0.5
+                    update_needed = turn > ROTATION_THRESHOLD
             if update_needed:
                 # Clear the force sort flag if it was set
                 if force_sort:
@@ -267,6 +275,7 @@ def sna_viewport_render_A3941(SH_DEGREE, SORT_THRESHOLD):
                         data=indices_buffer
                     )
                 bpy.gaussian_last_camera_pos = current_camera_pos
+                bpy.gaussian_last_view_dir = current_camera_dir
                 return True
             return False
         except Exception as e:


### PR DESCRIPTION
Fixes #68.

Thanks for the review — you were right that the position check can't affect the sort order, so this implements the direction-only version you suggested rather than ORing the two checks.

## Root cause

Depth for a splat is `(r . p) + d`, where `r` is row 2 of the view matrix and `d` is the same constant for every splat. Camera translation shifts every depth by that constant and therefore cannot permute the sort order; only a change of view direction can.

`update_depth_sorting()` gated re-sorting on camera position, so turning the viewport in place left the previous order in place and the alpha layers composited back-to-front, washing the viewport in a milky haze. A normal orbit changes position and direction together, so the position check fired as a side effect and masked the bug — which is why the repro is specifically turn-in-place.

## Changes

- `src/viewport_render.py` — gate re-sorting on the view direction, tracked in `bpy.gaussian_last_view_dir`. This also drops the re-sorts on pan and dolly, which were no-ops on the output.
- `__init__.py` — new `rt_rotation_sort_threshold` FloatProperty (default `0.02`, roughly 1°) on `sna_dgs_scene_properties`. Added as a new property rather than repurposing `r2_sort_threshold`, which is stored in existing .blend files.
- `src/r2_update_menu.py` — UI row for the new threshold ("Camera Turn Sort Threshold"), next to the existing one.
- `src/clean_up_scene_5f1f1.py` — `gaussian_last_view_dir` added to the teardown list.

`sna_viewport_render_A3941()` takes the new threshold as a third argument; all five call sites are updated.

## Testing

Verified on **Blender 5.2.0 LTS** (fbe6228777e7), Linux x64, working copy symlinked into `extensions/user_default` per CONTRIBUTING:

- Turning the view 180° in place no longer produces the haze. This was fully reproducible before the change.
- No stutter when orbiting quickly at the default threshold.
- The addon registers cleanly and both properties come up with the expected defaults.

## One question

With the position check gone, `r2_sort_threshold` no longer gates anything, so its existing UI row ("Camera Move Sort Threshold") is now inert. I left the property and the row untouched since the property lives in saved .blends and removing the row felt out of scope here. Happy to deprecate or hide it in a follow-up if you'd prefer.
