### PR TITLE
Remove generated UI no-ops

### DIFF
--- a/src/about_kiri_links_docs_3dgs.py
+++ b/src/about_kiri_links_docs_3dgs.py
@@ -9,105 +9,28 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_about_kiri_links_docs_3dgs_D02EC(layout_function, ):
     box_12166 = layout_function.box()
-    box_12166.alert = False
-    box_12166.enabled = True
-    box_12166.active = True
-    box_12166.use_property_split = False
-    box_12166.use_property_decorate = False
-    box_12166.alignment = 'Expand'.upper()
-    box_12166.scale_x = 1.0
-    box_12166.scale_y = 1.0
-    if not True: box_12166.operator_context = "EXEC_DEFAULT"
     col_CB7BF = box_12166.column(heading='', align=True)
-    col_CB7BF.alert = False
-    col_CB7BF.enabled = True
-    col_CB7BF.active = True
-    col_CB7BF.use_property_split = False
-    col_CB7BF.use_property_decorate = False
-    col_CB7BF.scale_x = 1.0
-    col_CB7BF.scale_y = 1.0
-    col_CB7BF.alignment = 'Expand'.upper()
-    col_CB7BF.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     box_D36BE = col_CB7BF.box()
-    box_D36BE.alert = False
-    box_D36BE.enabled = True
-    box_D36BE.active = True
-    box_D36BE.use_property_split = False
-    box_D36BE.use_property_decorate = False
     box_D36BE.alignment = 'Center'.upper()
-    box_D36BE.scale_x = 1.0
-    box_D36BE.scale_y = 1.0
-    if not True: box_D36BE.operator_context = "EXEC_DEFAULT"
     box_D36BE.label(text='About KIRI Engine', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
     box_D36BE.template_icon(icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'Addon speel 2.png')), scale=10.0)
     op = box_D36BE.operator('sna.dgs_render_launch_site_bf973', text='Learn More', icon_value=0, emboss=True, depress=False)
     op.sna_site_address = 'https://www.kiriengine.app/'
     box_28D7F = col_CB7BF.box()
-    box_28D7F.alert = False
-    box_28D7F.enabled = True
-    box_28D7F.active = True
-    box_28D7F.use_property_split = False
-    box_28D7F.use_property_decorate = True
-    box_28D7F.alignment = 'Expand'.upper()
-    box_28D7F.scale_x = 1.0
     box_28D7F.scale_y = 1.2000000476837158
-    if not True: box_28D7F.operator_context = "EXEC_DEFAULT"
     split_06A78 = box_28D7F.split(factor=0.5, align=False)
-    split_06A78.alert = False
-    split_06A78.enabled = True
-    split_06A78.active = True
-    split_06A78.use_property_split = False
-    split_06A78.use_property_decorate = False
-    split_06A78.scale_x = 1.0
-    split_06A78.scale_y = 1.0
-    split_06A78.alignment = 'Expand'.upper()
-    if not True: split_06A78.operator_context = "EXEC_DEFAULT"
     split_06A78.label(text='Documentation', icon_value=0)
     row_273F5 = split_06A78.row(heading='', align=False)
-    row_273F5.alert = False
-    row_273F5.enabled = True
-    row_273F5.active = True
-    row_273F5.use_property_split = False
-    row_273F5.use_property_decorate = False
-    row_273F5.scale_x = 1.0
-    row_273F5.scale_y = 1.0
     row_273F5.alignment = 'Right'.upper()
-    row_273F5.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     op = row_273F5.operator('sna.dgs_render_launch_site_bf973', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'documentation.svg')), emboss=True, depress=False)
     op.sna_site_address = 'https://www.kiriengine.app/blender-addon/3dgs-render'
     op = row_273F5.operator('sna.dgs_render_launch_site_bf973', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'video.svg')), emboss=True, depress=False)
     op.sna_site_address = 'https://www.youtube.com/@BlenderAddon-fromKIRI'
     box_DE3AB = col_CB7BF.box()
-    box_DE3AB.alert = False
-    box_DE3AB.enabled = True
-    box_DE3AB.active = True
-    box_DE3AB.use_property_split = False
-    box_DE3AB.use_property_decorate = False
-    box_DE3AB.alignment = 'Expand'.upper()
-    box_DE3AB.scale_x = 1.0
-    box_DE3AB.scale_y = 1.0
-    if not True: box_DE3AB.operator_context = "EXEC_DEFAULT"
     row_7D004 = box_DE3AB.row(heading='', align=False)
-    row_7D004.alert = False
-    row_7D004.enabled = True
-    row_7D004.active = True
-    row_7D004.use_property_split = False
-    row_7D004.use_property_decorate = False
-    row_7D004.scale_x = 1.0
     row_7D004.scale_y = 1.2000000476837158
-    row_7D004.alignment = 'Expand'.upper()
-    row_7D004.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     row_7D004.label(text='Get More Addons', icon_value=0)
     split_649B4 = row_7D004.split(factor=0.5, align=False)
-    split_649B4.alert = False
-    split_649B4.enabled = True
-    split_649B4.active = True
-    split_649B4.use_property_split = False
-    split_649B4.use_property_decorate = False
-    split_649B4.scale_x = 1.0
-    split_649B4.scale_y = 1.0
-    split_649B4.alignment = 'Expand'.upper()
-    if not True: split_649B4.operator_context = "EXEC_DEFAULT"
     op = split_649B4.operator('sna.dgs_render_launch_site_bf973', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'SuperHive Logo White.png')), emboss=True, depress=False)
     op.sna_site_address = 'https://blendermarket.com/creators/blender-addon-from-kiri-engine'
     op = split_649B4.operator('sna.dgs_render_launch_site_bf973', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'kiriengine blender addon icon color.svg')), emboss=True, depress=False)

--- a/src/active_3dgs_mesh_object_menu.py
+++ b/src/active_3dgs_mesh_object_menu.py
@@ -9,78 +9,17 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_active_3dgs_mesh_object_menu_9588F(layout_function, ):
     col_33976 = layout_function.column(heading='', align=False)
-    col_33976.alert = False
-    col_33976.enabled = True
-    col_33976.active = True
-    col_33976.use_property_split = False
-    col_33976.use_property_decorate = False
-    col_33976.scale_x = 1.0
-    col_33976.scale_y = 1.0
-    col_33976.alignment = 'Expand'.upper()
-    col_33976.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Render_GN' in bpy.context.view_layer.objects.active.modifiers):
         box_1AD2D = col_33976.box()
-        box_1AD2D.alert = False
-        box_1AD2D.enabled = True
-        box_1AD2D.active = True
-        box_1AD2D.use_property_split = False
-        box_1AD2D.use_property_decorate = False
-        box_1AD2D.alignment = 'Expand'.upper()
-        box_1AD2D.scale_x = 1.0
-        box_1AD2D.scale_y = 1.0
-        if not True: box_1AD2D.operator_context = "EXEC_DEFAULT"
         col_A4D20 = box_1AD2D.column(heading='', align=False)
-        col_A4D20.alert = False
-        col_A4D20.enabled = True
-        col_A4D20.active = True
-        col_A4D20.use_property_split = False
-        col_A4D20.use_property_decorate = False
-        col_A4D20.scale_x = 1.0
-        col_A4D20.scale_y = 1.0
-        col_A4D20.alignment = 'Expand'.upper()
-        col_A4D20.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         col_247F1 = col_A4D20.column(heading='', align=False)
-        col_247F1.alert = False
-        col_247F1.enabled = True
-        col_247F1.active = True
-        col_247F1.use_property_split = False
-        col_247F1.use_property_decorate = False
-        col_247F1.scale_x = 1.0
-        col_247F1.scale_y = 1.0
-        col_247F1.alignment = 'Expand'.upper()
-        col_247F1.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         col_247F1.label(text='Active 3DGS Mesh Object:', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
         row_0AD6D = col_A4D20.row(heading='', align=True)
-        row_0AD6D.alert = False
-        row_0AD6D.enabled = True
-        row_0AD6D.active = True
-        row_0AD6D.use_property_split = False
-        row_0AD6D.use_property_decorate = False
-        row_0AD6D.scale_x = 1.0
-        row_0AD6D.scale_y = 1.0
-        row_0AD6D.alignment = 'Expand'.upper()
-        row_0AD6D.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         box_29E44 = row_0AD6D.box()
-        box_29E44.alert = False
-        box_29E44.enabled = True
-        box_29E44.active = True
-        box_29E44.use_property_split = False
-        box_29E44.use_property_decorate = False
-        box_29E44.alignment = 'Expand'.upper()
-        box_29E44.scale_x = 1.0
-        box_29E44.scale_y = 1.0
-        if not True: box_29E44.operator_context = "EXEC_DEFAULT"
         box_29E44.label(text=bpy.context.view_layer.objects.active.name, icon_value=0)
         col_F0A3B = row_0AD6D.column(heading='', align=False)
         col_F0A3B.alert = (bpy.context.view_layer.objects.active.sna_dgs_object_properties.update_mode == 'Disable Camera Updates')
-        col_F0A3B.enabled = True
-        col_F0A3B.active = True
-        col_F0A3B.use_property_split = False
-        col_F0A3B.use_property_decorate = False
-        col_F0A3B.scale_x = 1.0
         col_F0A3B.scale_y = 1.5
-        col_F0A3B.alignment = 'Expand'.upper()
-        col_F0A3B.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         col_F0A3B.prop(bpy.context.view_layer.objects.active.sna_dgs_object_properties, 'update_mode', text='', icon_value=0, emboss=True, toggle=True)
         col_A4D20.separator(factor=1.0)
         if (bpy.context.view_layer.objects.active.sna_dgs_object_properties.update_mode == 'Enable Camera Updates'):
@@ -90,156 +29,41 @@ def sna_active_3dgs_mesh_object_menu_9588F(layout_function, ):
                         pass
                     else:
                         box_96194 = col_A4D20.box()
-                        box_96194.alert = False
-                        box_96194.enabled = True
-                        box_96194.active = True
-                        box_96194.use_property_split = False
-                        box_96194.use_property_decorate = False
-                        box_96194.alignment = 'Expand'.upper()
-                        box_96194.scale_x = 1.0
-                        box_96194.scale_y = 1.0
-                        if not True: box_96194.operator_context = "EXEC_DEFAULT"
                         row_A3F2D = box_96194.row(heading='', align=True)
-                        row_A3F2D.alert = False
-                        row_A3F2D.enabled = True
-                        row_A3F2D.active = True
-                        row_A3F2D.use_property_split = False
-                        row_A3F2D.use_property_decorate = False
-                        row_A3F2D.scale_x = 1.0
-                        row_A3F2D.scale_y = 1.0
-                        row_A3F2D.alignment = 'Expand'.upper()
-                        row_A3F2D.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                         op = row_A3F2D.operator('sna.dgs_render_align_active_to_x_axis_6ae0e', text='X', icon_value=0, emboss=True, depress=False)
                         op = row_A3F2D.operator('sna.dgs_render_align_active_to_y_axis_c305d', text='Y', icon_value=0, emboss=True, depress=False)
                         op = row_A3F2D.operator('sna.dgs_render_align_active_to_z_axis_1e184', text='Z', icon_value=0, emboss=True, depress=False)
             else:
                 box_1444A = col_A4D20.box()
-                box_1444A.alert = False
-                box_1444A.enabled = True
-                box_1444A.active = True
-                box_1444A.use_property_split = False
-                box_1444A.use_property_decorate = False
-                box_1444A.alignment = 'Expand'.upper()
-                box_1444A.scale_x = 1.0
-                box_1444A.scale_y = 1.0
-                if not True: box_1444A.operator_context = "EXEC_DEFAULT"
                 op = box_1444A.operator('sna.dgs_render_align_active_to_view_30b13', text=('Refresh update to camera' if ((bpy.context.scene.camera != None) and bpy.context.view_layer.objects.active.sna_dgs_object_properties.cam_update) else 'Update Active To View'), icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'eye.svg')), emboss=True, depress=False)
         if (bpy.context.view_layer.objects.active.sna_dgs_object_properties.update_mode == 'Show As Point Cloud'):
             box_AA375 = col_A4D20.box()
-            box_AA375.alert = False
-            box_AA375.enabled = True
-            box_AA375.active = True
-            box_AA375.use_property_split = False
-            box_AA375.use_property_decorate = False
-            box_AA375.alignment = 'Expand'.upper()
-            box_AA375.scale_x = 1.0
-            box_AA375.scale_y = 1.0
-            if not True: box_AA375.operator_context = "EXEC_DEFAULT"
             attr_C8F44 = '["' + str('Socket_51' + '"]') 
             box_AA375.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], attr_C8F44), text='Point Radius', icon_value=0, emboss=True)
             box_AA375.prop_search(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], '["Socket_61"]'), bpy.data, 'materials', text='Material', icon='NONE', item_search_property="name")
         if (bpy.context.view_layer.objects.active.sna_dgs_object_properties.update_mode == 'Enable Camera Updates'):
             col_75D68 = col_A4D20.column(heading='', align=False)
-            col_75D68.alert = False
-            col_75D68.enabled = True
-            col_75D68.active = True
-            col_75D68.use_property_split = False
-            col_75D68.use_property_decorate = False
-            col_75D68.scale_x = 1.0
-            col_75D68.scale_y = 1.0
-            col_75D68.alignment = 'Expand'.upper()
-            col_75D68.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             if ((bpy.context.scene.camera == None) and bpy.context.view_layer.objects.active.sna_dgs_object_properties.cam_update):
                 box_A3A41 = col_75D68.box()
-                box_A3A41.alert = False
-                box_A3A41.enabled = True
-                box_A3A41.active = True
-                box_A3A41.use_property_split = False
-                box_A3A41.use_property_decorate = False
-                box_A3A41.alignment = 'Expand'.upper()
-                box_A3A41.scale_x = 1.0
-                box_A3A41.scale_y = 1.0
-                if not True: box_A3A41.operator_context = "EXEC_DEFAULT"
                 box_A3A41.label(text='No Active Camera Found', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
             box_21A87 = col_75D68.box()
             box_21A87.alert = bpy.context.view_layer.objects.active.sna_dgs_object_properties.cam_update
-            box_21A87.enabled = True
-            box_21A87.active = True
-            box_21A87.use_property_split = False
-            box_21A87.use_property_decorate = False
-            box_21A87.alignment = 'Expand'.upper()
-            box_21A87.scale_x = 1.0
             box_21A87.scale_y = 1.5
-            if not True: box_21A87.operator_context = "EXEC_DEFAULT"
             box_21A87.prop(bpy.context.view_layer.objects.active.sna_dgs_object_properties, 'cam_update', text='Use Active Camera', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'camera.svg')), emboss=True, toggle=True)
             if (bpy.context.view_layer.objects.active.sna_dgs_object_properties.cam_update and (bpy.context.scene.camera != None) and property_exists("bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_68']", globals(), locals()) and property_exists("None", globals(), locals())):
                 col_C389F = col_75D68.column(heading='', align=True)
-                col_C389F.alert = False
-                col_C389F.enabled = True
-                col_C389F.active = True
-                col_C389F.use_property_split = False
-                col_C389F.use_property_decorate = False
-                col_C389F.scale_x = 1.0
-                col_C389F.scale_y = 1.0
-                col_C389F.alignment = 'Expand'.upper()
-                col_C389F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 box_81D6E = col_C389F.box()
-                box_81D6E.alert = False
-                box_81D6E.enabled = True
-                box_81D6E.active = True
-                box_81D6E.use_property_split = False
-                box_81D6E.use_property_decorate = False
-                box_81D6E.alignment = 'Expand'.upper()
-                box_81D6E.scale_x = 1.0
-                box_81D6E.scale_y = 1.0
-                if not True: box_81D6E.operator_context = "EXEC_DEFAULT"
                 row_BAB68 = box_81D6E.row(heading='', align=False)
-                row_BAB68.alert = False
-                row_BAB68.enabled = True
-                row_BAB68.active = True
-                row_BAB68.use_property_split = False
-                row_BAB68.use_property_decorate = False
-                row_BAB68.scale_x = 1.0
-                row_BAB68.scale_y = 1.0
-                row_BAB68.alignment = 'Expand'.upper()
-                row_BAB68.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 attr_47247 = '["' + str('Socket_68' + '"]') 
                 row_BAB68.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], attr_47247), text='Frustrum Cull (Edit Mode)', icon_value=0, emboss=True)
                 if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_68']:
                     split_06E70 = row_BAB68.split(factor=0.30000001192092896, align=False)
-                    split_06E70.alert = False
-                    split_06E70.enabled = True
-                    split_06E70.active = True
-                    split_06E70.use_property_split = False
-                    split_06E70.use_property_decorate = False
-                    split_06E70.scale_x = 1.0
-                    split_06E70.scale_y = 1.0
-                    split_06E70.alignment = 'Expand'.upper()
-                    if not True: split_06E70.operator_context = "EXEC_DEFAULT"
                     attr_F00D7 = '["' + str('Socket_74' + '"]') 
                     split_06E70.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], attr_F00D7), text='Invert', icon_value=0, emboss=True)
                     attr_D8000 = '["' + str('Socket_63' + '"]') 
                     split_06E70.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], attr_D8000), text='Padding', icon_value=0, emboss=True)
                 box_D224C = col_C389F.box()
-                box_D224C.alert = False
-                box_D224C.enabled = True
-                box_D224C.active = True
-                box_D224C.use_property_split = False
-                box_D224C.use_property_decorate = False
-                box_D224C.alignment = 'Expand'.upper()
-                box_D224C.scale_x = 1.0
-                box_D224C.scale_y = 1.0
-                if not True: box_D224C.operator_context = "EXEC_DEFAULT"
                 row_03A56 = box_D224C.row(heading='', align=False)
-                row_03A56.alert = False
-                row_03A56.enabled = True
-                row_03A56.active = True
-                row_03A56.use_property_split = False
-                row_03A56.use_property_decorate = False
-                row_03A56.scale_x = 1.0
-                row_03A56.scale_y = 1.0
-                row_03A56.alignment = 'Expand'.upper()
-                row_03A56.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 attr_12DA6 = '["' + str('Socket_69' + '"]') 
                 row_03A56.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], attr_12DA6), text='Distance Cull (Edit Mode)', icon_value=0, emboss=True)
                 if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_69']:
@@ -247,15 +71,6 @@ def sna_active_3dgs_mesh_object_menu_9588F(layout_function, ):
                     row_03A56.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], attr_29452), text='Use Camera Clip Range', icon_value=0, emboss=True)
                 if ( not bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_72'] and bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN']['Socket_69']):
                     row_050CC = box_D224C.row(heading='', align=False)
-                    row_050CC.alert = False
-                    row_050CC.enabled = True
-                    row_050CC.active = True
-                    row_050CC.use_property_split = False
-                    row_050CC.use_property_decorate = False
-                    row_050CC.scale_x = 1.0
-                    row_050CC.scale_y = 1.0
-                    row_050CC.alignment = 'Expand'.upper()
-                    row_050CC.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                     attr_47D5F = '["' + str('Socket_70' + '"]') 
                     row_050CC.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_GN'], attr_47D5F), text='Near Distance', icon_value=0, emboss=True)
                     attr_05FB6 = '["' + str('Socket_71' + '"]') 

--- a/src/add_animate_modifier.py
+++ b/src/add_animate_modifier.py
@@ -17,9 +17,9 @@ class SNA_OT_Dgs_Render_Add_Animate_Modifier_39C55(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         if (bpy.context.view_layer.objects.active.type == 'MESH' or bpy.context.view_layer.objects.active.type == 'CURVE'):

--- a/src/add_to_view3d_mt_object_apply.py
+++ b/src/add_to_view3d_mt_object_apply.py
@@ -12,15 +12,6 @@ def sna_add_to_view3d_mt_object_apply_4C860(self, context):
         layout = self.layout
         if '3DGS_Mesh_Type' in bpy.context.view_layer.objects.active:
             col_B3C28 = layout.column(heading='', align=False)
-            col_B3C28.alert = False
-            col_B3C28.enabled = True
-            col_B3C28.active = True
-            col_B3C28.use_property_split = False
-            col_B3C28.use_property_decorate = False
-            col_B3C28.scale_x = 1.0
-            col_B3C28.scale_y = 1.0
-            col_B3C28.alignment = 'Expand'.upper()
-            col_B3C28.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             op = col_B3C28.operator('sna.dgs_render_apply_3dgs_tranforms_5b665', text='Apply 3DGS Transforms', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')), emboss=True, depress=False)
             op.sna_apply_location = False
             if bpy.context.view_layer.objects.active['3DGS_Mesh_Type'] == "face":

--- a/src/add_uv_edit_modifier.py
+++ b/src/add_uv_edit_modifier.py
@@ -17,9 +17,9 @@ class SNA_OT_Dgs_Render_Add_Uv_Edit_Modifier_E8Ae6(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         if (bpy.context.view_layer.objects.active.type == 'MESH' or bpy.context.view_layer.objects.active.type == 'CURVE'):

--- a/src/addon_preferences.py
+++ b/src/addon_preferences.py
@@ -18,48 +18,12 @@ class SNA_AddonPreferences_AB8B3(bpy.types.AddonPreferences):
         if not (False):
             layout = self.layout 
             box_D84AF = layout.box()
-            box_D84AF.alert = False
-            box_D84AF.enabled = True
-            box_D84AF.active = True
-            box_D84AF.use_property_split = False
-            box_D84AF.use_property_decorate = False
-            box_D84AF.alignment = 'Expand'.upper()
-            box_D84AF.scale_x = 1.0
-            box_D84AF.scale_y = 1.0
-            if not True: box_D84AF.operator_context = "EXEC_DEFAULT"
             box_236E6 = box_D84AF.box()
-            box_236E6.alert = False
-            box_236E6.enabled = True
-            box_236E6.active = True
-            box_236E6.use_property_split = False
-            box_236E6.use_property_decorate = False
-            box_236E6.alignment = 'Expand'.upper()
-            box_236E6.scale_x = 1.0
-            box_236E6.scale_y = 1.0
-            if not True: box_236E6.operator_context = "EXEC_DEFAULT"
             box_236E6.label(text='Cache', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
             box_236E6.prop(bpy.context.preferences.addons[__package__].preferences, 'sna_cache_file_directory', text='Cache directory', icon_value=0, emboss=True)
             box_F03E4 = box_236E6.box()
-            box_F03E4.alert = False
-            box_F03E4.enabled = True
-            box_F03E4.active = True
-            box_F03E4.use_property_split = False
-            box_F03E4.use_property_decorate = False
-            box_F03E4.alignment = 'Expand'.upper()
-            box_F03E4.scale_x = 1.0
-            box_F03E4.scale_y = 1.0
-            if not True: box_F03E4.operator_context = "EXEC_DEFAULT"
             box_F03E4.label(text='If cache files are removed or disconnected, it may not be possible to restore the original state', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
             box_F03E4.label(text='of light baked or rig-deformed objects. Try to maintained a stable cache location.', icon_value=0)
             box_24429 = box_D84AF.box()
-            box_24429.alert = False
-            box_24429.enabled = True
-            box_24429.active = True
-            box_24429.use_property_split = False
-            box_24429.use_property_decorate = False
-            box_24429.alignment = 'Expand'.upper()
-            box_24429.scale_x = 1.0
-            box_24429.scale_y = 1.0
-            if not True: box_24429.operator_context = "EXEC_DEFAULT"
             box_24429.label(text='Tips', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
             box_24429.prop(bpy.context.preferences.addons[__package__].preferences, 'sna_show_tips', text='Show tips throughout the interface', icon_value=0, emboss=True)

--- a/src/adjust_attributes.py
+++ b/src/adjust_attributes.py
@@ -11,52 +11,17 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_adjust_attributes_AB643(layout_function, ):
     if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Adjust_Attributes_GN' in bpy.context.view_layer.objects.active.modifiers):
         col_15AC3 = layout_function.column(heading='', align=False)
-        col_15AC3.alert = False
-        col_15AC3.enabled = True
-        col_15AC3.active = True
-        col_15AC3.use_property_split = False
-        col_15AC3.use_property_decorate = False
-        col_15AC3.scale_x = 1.0
-        col_15AC3.scale_y = 1.0
-        col_15AC3.alignment = 'Expand'.upper()
-        col_15AC3.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         layout_function = col_15AC3
         sna_attribute_adjust_properties_2C323(layout_function, )
         box_6671A = col_15AC3.box()
-        box_6671A.alert = False
-        box_6671A.enabled = True
-        box_6671A.active = True
-        box_6671A.use_property_split = False
-        box_6671A.use_property_decorate = False
-        box_6671A.alignment = 'Expand'.upper()
-        box_6671A.scale_x = 1.0
-        box_6671A.scale_y = 1.0
-        if not True: box_6671A.operator_context = "EXEC_DEFAULT"
         box_6671A.label(text='Accurate value changes may only ', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_6671A.label(text='be visible in Render mode and external', icon_value=0)
         box_6671A.label(text='3DGS viewers. This modifier will show in', icon_value=0)
         box_6671A.label(text='Render mode for the active object.', icon_value=0)
     else:
         box_6555D = layout_function.box()
-        box_6555D.alert = False
         box_6555D.enabled = 'OBJECT'==bpy.context.mode
-        box_6555D.active = True
-        box_6555D.use_property_split = False
-        box_6555D.use_property_decorate = False
-        box_6555D.alignment = 'Expand'.upper()
-        box_6555D.scale_x = 1.0
-        box_6555D.scale_y = 1.0
-        if not True: box_6555D.operator_context = "EXEC_DEFAULT"
         row_220DB = box_6555D.row(heading='', align=False)
-        row_220DB.alert = False
-        row_220DB.enabled = True
-        row_220DB.active = True
-        row_220DB.use_property_split = False
-        row_220DB.use_property_decorate = False
-        row_220DB.scale_x = 1.0
-        row_220DB.scale_y = 1.0
-        row_220DB.alignment = 'Expand'.upper()
-        row_220DB.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_220DB.label(text='Adjust Attributes', icon_value=0)
         op = row_220DB.operator('sna.dgs_render_append_geometry_node_modifier_c2492', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'plus-circle.svg')), emboss=True, depress=False)
         op.sna_node_group_name = 'KIRI_3DGS_Adjust_Attributes_GN'

--- a/src/advanced_render.py
+++ b/src/advanced_render.py
@@ -17,9 +17,9 @@ class SNA_OT_Dgs_Render_Advanced_Render_147Af(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         exec('import os')

--- a/src/align_active_to_view.py
+++ b/src/align_active_to_view.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Align_Active_To_View_30B13(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         ObjectName = bpy.context.view_layer.objects.active.name

--- a/src/align_active_to_x_axis.py
+++ b/src/align_active_to_x_axis.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Align_Active_To_X_Axis_6Ae0E(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         sna_align_active_values_to_x_4CE1F()

--- a/src/align_active_to_y_axis.py
+++ b/src/align_active_to_y_axis.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Align_Active_To_Y_Axis_C305D(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         sna_align_active_values_to_y_E5E9E()

--- a/src/align_active_to_z_axis.py
+++ b/src/align_active_to_z_axis.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Align_Active_To_Z_Axis_1E184(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         sna_align_active_values_to_z_7B9ED()

--- a/src/animate_function_interface.py
+++ b/src/animate_function_interface.py
@@ -13,76 +13,23 @@ def sna_animate_function_interface_57F9E(layout_function, ):
     sna_append_wire_primitives_15D73(layout_function, )
     if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Animate_GN' in bpy.context.view_layer.objects.active.modifiers):
         box_1DAB6 = layout_function.box()
-        box_1DAB6.alert = False
-        box_1DAB6.enabled = True
-        box_1DAB6.active = True
-        box_1DAB6.use_property_split = False
-        box_1DAB6.use_property_decorate = False
-        box_1DAB6.alignment = 'Expand'.upper()
-        box_1DAB6.scale_x = 1.0
-        box_1DAB6.scale_y = 1.0
-        if not True: box_1DAB6.operator_context = "EXEC_DEFAULT"
         split_D18F1 = box_1DAB6.split(factor=0.5, align=False)
-        split_D18F1.alert = False
-        split_D18F1.enabled = True
-        split_D18F1.active = True
-        split_D18F1.use_property_split = False
-        split_D18F1.use_property_decorate = False
-        split_D18F1.scale_x = 1.0
-        split_D18F1.scale_y = 1.0
-        split_D18F1.alignment = 'Expand'.upper()
-        if not True: split_D18F1.operator_context = "EXEC_DEFAULT"
         split_D18F1.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], 'show_viewport', text='Animate', icon_value=0, emboss=True, toggle=True)
         row_058B1 = split_D18F1.row(heading='', align=True)
-        row_058B1.alert = False
-        row_058B1.enabled = True
-        row_058B1.active = True
-        row_058B1.use_property_split = False
-        row_058B1.use_property_decorate = False
-        row_058B1.scale_x = 1.0
-        row_058B1.scale_y = 1.0
         row_058B1.alignment = 'Right'.upper()
-        row_058B1.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_058B1.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], 'show_render', text='', icon_value=0, emboss=True, toggle=True)
         op = row_058B1.operator('sna.dgs_render_apply_animate_modifier_3938e', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'check.svg')), emboss=True, depress=False)
         op = row_058B1.operator('sna.dgs_render_remove_modifier_9cf0d', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'trash.svg')), emboss=True, depress=False)
         op.sna_target_object = bpy.context.view_layer.objects.active.name
         op.sna_target_modifier = 'KIRI_3DGS_Animate_GN'
         col_03A93 = box_1DAB6.column(heading='', align=False)
-        col_03A93.alert = False
-        col_03A93.enabled = True
-        col_03A93.active = True
-        col_03A93.use_property_split = False
-        col_03A93.use_property_decorate = False
-        col_03A93.scale_x = 1.0
-        col_03A93.scale_y = 1.0
-        col_03A93.alignment = 'Expand'.upper()
-        col_03A93.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         box_797F1 = col_03A93.box()
-        box_797F1.alert = False
-        box_797F1.enabled = True
-        box_797F1.active = True
-        box_797F1.use_property_split = False
-        box_797F1.use_property_decorate = False
-        box_797F1.alignment = 'Expand'.upper()
-        box_797F1.scale_x = 1.0
-        box_797F1.scale_y = 1.0
-        if not True: box_797F1.operator_context = "EXEC_DEFAULT"
         attr_C6924 = '["' + str('Socket_6' + '"]') 
         box_797F1.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_C6924), text='', icon_value=0, emboss=True)
         if (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN']['Socket_6'] == 2):
             pass
         else:
             col_44B28 = box_797F1.column(heading='', align=False)
-            col_44B28.alert = False
-            col_44B28.enabled = True
-            col_44B28.active = True
-            col_44B28.use_property_split = False
-            col_44B28.use_property_decorate = False
-            col_44B28.scale_x = 1.0
-            col_44B28.scale_y = 1.0
-            col_44B28.alignment = 'Expand'.upper()
-            col_44B28.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             if (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN']['Socket_6'] == 0):
                 attr_3F944 = '["' + str('Socket_2' + '"]') 
                 col_44B28.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_3F944), text='', icon_value=0, emboss=True)
@@ -93,40 +40,13 @@ def sna_animate_function_interface_57F9E(layout_function, ):
             attr_D5EE1 = '["' + str('Socket_3' + '"]') 
             col_44B28.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_D5EE1), text='Distance Threshold', icon_value=0, emboss=True)
         box_3AE7F = col_03A93.box()
-        box_3AE7F.alert = False
-        box_3AE7F.enabled = True
-        box_3AE7F.active = True
-        box_3AE7F.use_property_split = False
-        box_3AE7F.use_property_decorate = False
-        box_3AE7F.alignment = 'Expand'.upper()
-        box_3AE7F.scale_x = 1.0
-        box_3AE7F.scale_y = 1.0
-        if not True: box_3AE7F.operator_context = "EXEC_DEFAULT"
         attr_A68D1 = '["' + str('Socket_37' + '"]') 
         box_3AE7F.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_A68D1), text='Decimate Animated', icon_value=0, emboss=True)
         box_F6C6C = col_03A93.box()
-        box_F6C6C.alert = False
-        box_F6C6C.enabled = True
-        box_F6C6C.active = True
-        box_F6C6C.use_property_split = False
-        box_F6C6C.use_property_decorate = False
-        box_F6C6C.alignment = 'Expand'.upper()
-        box_F6C6C.scale_x = 1.0
-        box_F6C6C.scale_y = 1.0
-        if not True: box_F6C6C.operator_context = "EXEC_DEFAULT"
         attr_FEA5B = '["' + str('Socket_26' + '"]') 
         box_F6C6C.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_FEA5B), text='', icon_value=0, emboss=True)
         if (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN']['Socket_26'] == 1):
             box_6DFC4 = box_F6C6C.box()
-            box_6DFC4.alert = False
-            box_6DFC4.enabled = True
-            box_6DFC4.active = True
-            box_6DFC4.use_property_split = False
-            box_6DFC4.use_property_decorate = False
-            box_6DFC4.alignment = 'Expand'.upper()
-            box_6DFC4.scale_x = 1.0
-            box_6DFC4.scale_y = 1.0
-            if not True: box_6DFC4.operator_context = "EXEC_DEFAULT"
             box_6DFC4.prop_search(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], '["Socket_44"]'), bpy.data, 'materials', text='Material', icon='NONE', item_search_property="name")
             attr_55AA7 = '["' + str('Socket_9' + '"]') 
             box_6DFC4.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_55AA7), text='Point Min Radius', icon_value=0, emboss=True)
@@ -141,15 +61,6 @@ def sna_animate_function_interface_57F9E(layout_function, ):
             box_6DFC4.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_9A7E1), text='Random Multiplier', icon_value=0, emboss=True)
         if (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN']['Socket_26'] == 2):
             box_91071 = box_F6C6C.box()
-            box_91071.alert = False
-            box_91071.enabled = True
-            box_91071.active = True
-            box_91071.use_property_split = False
-            box_91071.use_property_decorate = False
-            box_91071.alignment = 'Expand'.upper()
-            box_91071.scale_x = 1.0
-            box_91071.scale_y = 1.0
-            if not True: box_91071.operator_context = "EXEC_DEFAULT"
             box_91071.prop_search(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], '["Socket_44"]'), bpy.data, 'materials', text='Material', icon='NONE', item_search_property="name")
             attr_F4993 = '["' + str('Socket_38' + '"]') 
             box_91071.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_F4993), text='Curve Length', icon_value=0, emboss=True)
@@ -165,38 +76,11 @@ def sna_animate_function_interface_57F9E(layout_function, ):
             attr_53122 = '["' + str('Socket_34' + '"]') 
             box_91071.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_53122), text='Random Multiplier', icon_value=0, emboss=True)
         box_B4084 = col_03A93.box()
-        box_B4084.alert = False
-        box_B4084.enabled = True
-        box_B4084.active = True
-        box_B4084.use_property_split = False
-        box_B4084.use_property_decorate = False
-        box_B4084.alignment = 'Expand'.upper()
-        box_B4084.scale_x = 1.0
-        box_B4084.scale_y = 1.0
-        if not True: box_B4084.operator_context = "EXEC_DEFAULT"
         box_7D470 = box_B4084.box()
-        box_7D470.alert = False
-        box_7D470.enabled = True
-        box_7D470.active = True
-        box_7D470.use_property_split = False
-        box_7D470.use_property_decorate = False
-        box_7D470.alignment = 'Expand'.upper()
-        box_7D470.scale_x = 1.0
-        box_7D470.scale_y = 1.0
-        if not True: box_7D470.operator_context = "EXEC_DEFAULT"
         attr_52B76 = '["' + str('Socket_28' + '"]') 
         box_7D470.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_52B76), text='Enable Noise Displacement', icon_value=0, emboss=True, toggle=True)
         if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN']['Socket_28']:
             col_28235 = box_7D470.column(heading='', align=False)
-            col_28235.alert = False
-            col_28235.enabled = True
-            col_28235.active = True
-            col_28235.use_property_split = False
-            col_28235.use_property_decorate = False
-            col_28235.scale_x = 1.0
-            col_28235.scale_y = 1.0
-            col_28235.alignment = 'Expand'.upper()
-            col_28235.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_D3C6D = '["' + str('Socket_7' + '"]') 
             col_28235.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_D3C6D), text='Noise Strength', icon_value=0, emboss=True)
             attr_6D7D3 = '["' + str('Socket_8' + '"]') 
@@ -204,28 +88,10 @@ def sna_animate_function_interface_57F9E(layout_function, ):
             attr_18DA5 = '["' + str('Socket_4' + '"]') 
             col_28235.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_18DA5), text='Time Evolution Multiplier', icon_value=0, emboss=True)
         box_54317 = box_B4084.box()
-        box_54317.alert = False
-        box_54317.enabled = True
-        box_54317.active = True
-        box_54317.use_property_split = False
-        box_54317.use_property_decorate = False
-        box_54317.alignment = 'Expand'.upper()
-        box_54317.scale_x = 1.0
-        box_54317.scale_y = 1.0
-        if not True: box_54317.operator_context = "EXEC_DEFAULT"
         attr_FB923 = '["' + str('Socket_29' + '"]') 
         box_54317.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_FB923), text='Enable Voronoi Displacement', icon_value=0, emboss=True, toggle=True)
         if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN']['Socket_29']:
             col_E8E24 = box_54317.column(heading='', align=False)
-            col_E8E24.alert = False
-            col_E8E24.enabled = True
-            col_E8E24.active = True
-            col_E8E24.use_property_split = False
-            col_E8E24.use_property_decorate = False
-            col_E8E24.scale_x = 1.0
-            col_E8E24.scale_y = 1.0
-            col_E8E24.alignment = 'Expand'.upper()
-            col_E8E24.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_AEBD9 = '["' + str('Socket_21' + '"]') 
             col_E8E24.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_AEBD9), text='Voronoi Strength', icon_value=0, emboss=True)
             attr_D761F = '["' + str('Socket_20' + '"]') 
@@ -233,62 +99,18 @@ def sna_animate_function_interface_57F9E(layout_function, ):
             attr_6054A = '["' + str('Socket_22' + '"]') 
             col_E8E24.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_6054A), text='Time Evolution Multiplier', icon_value=0, emboss=True)
         box_554D7 = col_03A93.box()
-        box_554D7.alert = False
-        box_554D7.enabled = True
-        box_554D7.active = True
-        box_554D7.use_property_split = False
-        box_554D7.use_property_decorate = False
-        box_554D7.alignment = 'Expand'.upper()
-        box_554D7.scale_x = 1.0
-        box_554D7.scale_y = 1.0
-        if not True: box_554D7.operator_context = "EXEC_DEFAULT"
         box_E2A8B = box_554D7.box()
-        box_E2A8B.alert = False
-        box_E2A8B.enabled = True
-        box_E2A8B.active = True
-        box_E2A8B.use_property_split = False
-        box_E2A8B.use_property_decorate = False
-        box_E2A8B.alignment = 'Expand'.upper()
-        box_E2A8B.scale_x = 1.0
-        box_E2A8B.scale_y = 1.0
-        if not True: box_E2A8B.operator_context = "EXEC_DEFAULT"
         attr_FE6FE = '["' + str('Socket_41' + '"]') 
         box_E2A8B.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_FE6FE), text='Enable Pixelate', icon_value=0, emboss=True, toggle=True)
         if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN']['Socket_41']:
             col_5DE3D = box_E2A8B.column(heading='', align=False)
-            col_5DE3D.alert = False
-            col_5DE3D.enabled = True
-            col_5DE3D.active = True
-            col_5DE3D.use_property_split = False
-            col_5DE3D.use_property_decorate = False
-            col_5DE3D.scale_x = 1.0
-            col_5DE3D.scale_y = 1.0
-            col_5DE3D.alignment = 'Expand'.upper()
-            col_5DE3D.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_0E515 = '["' + str('Socket_40' + '"]') 
             col_5DE3D.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_0E515), text='Pixelate Mix', icon_value=0, emboss=True)
             attr_9C041 = '["' + str('Socket_39' + '"]') 
             col_5DE3D.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN'], attr_9C041), text='Grid Scale', icon_value=0, emboss=True)
     else:
         box_F44AB = layout_function.box()
-        box_F44AB.alert = False
         box_F44AB.enabled = 'OBJECT'==bpy.context.mode
-        box_F44AB.active = True
-        box_F44AB.use_property_split = False
-        box_F44AB.use_property_decorate = False
-        box_F44AB.alignment = 'Expand'.upper()
-        box_F44AB.scale_x = 1.0
-        box_F44AB.scale_y = 1.0
-        if not True: box_F44AB.operator_context = "EXEC_DEFAULT"
         row_07DA9 = box_F44AB.row(heading='', align=False)
-        row_07DA9.alert = False
-        row_07DA9.enabled = True
-        row_07DA9.active = True
-        row_07DA9.use_property_split = False
-        row_07DA9.use_property_decorate = False
-        row_07DA9.scale_x = 1.0
-        row_07DA9.scale_y = 1.0
-        row_07DA9.alignment = 'Expand'.upper()
-        row_07DA9.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_07DA9.label(text='Animate', icon_value=0)
         op = row_07DA9.operator('sna.dgs_render_add_animate_modifier_39c55', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'plus-circle.svg')), emboss=True, depress=False)

--- a/src/append_geometry_node_modifier.py
+++ b/src/append_geometry_node_modifier.py
@@ -18,9 +18,9 @@ class SNA_OT_Dgs_Render_Append_Geometry_Node_Modifier_C2492(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         if (bpy.context.view_layer.objects.active.type == 'MESH' or bpy.context.view_layer.objects.active.type == 'CURVE'):

--- a/src/append_rough_mesh_modifier.py
+++ b/src/append_rough_mesh_modifier.py
@@ -19,9 +19,9 @@ class SNA_OT_Dgs_Render_Append_Rough_Mesh_Modifier_65Da3(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         if (bpy.context.view_layer.objects.active.type == 'MESH' or bpy.context.view_layer.objects.active.type == 'CURVE'):
@@ -126,26 +126,8 @@ class SNA_OT_Dgs_Render_Append_Rough_Mesh_Modifier_65Da3(bpy.types.Operator):
     def draw(self, context):
         layout = self.layout
         box_48B99 = layout.box()
-        box_48B99.alert = False
-        box_48B99.enabled = True
-        box_48B99.active = True
-        box_48B99.use_property_split = False
-        box_48B99.use_property_decorate = False
-        box_48B99.alignment = 'Expand'.upper()
-        box_48B99.scale_x = 1.0
-        box_48B99.scale_y = 1.0
-        if not True: box_48B99.operator_context = "EXEC_DEFAULT"
         box_48B99.label(text='Objects imported as Verts will produce smoother meshes', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_F6B46 = layout.box()
-        box_F6B46.alert = False
-        box_F6B46.enabled = True
-        box_F6B46.active = True
-        box_F6B46.use_property_split = False
-        box_F6B46.use_property_decorate = False
-        box_F6B46.alignment = 'Expand'.upper()
-        box_F6B46.scale_x = 1.0
-        box_F6B46.scale_y = 1.0
-        if not True: box_F6B46.operator_context = "EXEC_DEFAULT"
         box_F6B46.prop(self, 'sna_create_duplicate', text='Create a duplicate object', icon_value=0, emboss=True)
         if self.sna_create_duplicate:
             pass

--- a/src/append_wire_cube.py
+++ b/src/append_wire_cube.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Append_Wire_Cube_56E0F(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         if 'EDIT_MESH'==bpy.context.mode:

--- a/src/append_wire_effectors.py
+++ b/src/append_wire_effectors.py
@@ -9,14 +9,5 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_append_wire_effectors_D3038(layout_function, ):
     box_C9715 = layout_function.box()
-    box_C9715.alert = False
-    box_C9715.enabled = True
-    box_C9715.active = True
-    box_C9715.use_property_split = False
-    box_C9715.use_property_decorate = False
-    box_C9715.alignment = 'Expand'.upper()
-    box_C9715.scale_x = 1.0
-    box_C9715.scale_y = 1.0
-    if not True: box_C9715.operator_context = "EXEC_DEFAULT"
     op = box_C9715.operator('sna.dgs_render_append_wire_sphere_2bf63', text='Add Wire Sphere', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'noun-sphere-7915480-FFFFFF.svg')), emboss=True, depress=False)
     op = box_C9715.operator('sna.dgs_render_append_wire_cube_56e0f', text='Add Wire Cube', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'noun-cube-7915485-FFFFFF.svg')), emboss=True, depress=False)

--- a/src/append_wire_primitives.py
+++ b/src/append_wire_primitives.py
@@ -9,14 +9,5 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_append_wire_primitives_15D73(layout_function, ):
     col_4F908 = layout_function.column(heading='', align=True)
-    col_4F908.alert = False
-    col_4F908.enabled = True
-    col_4F908.active = True
-    col_4F908.use_property_split = False
-    col_4F908.use_property_decorate = False
-    col_4F908.scale_x = 1.0
-    col_4F908.scale_y = 1.0
-    col_4F908.alignment = 'Expand'.upper()
-    col_4F908.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     op = col_4F908.operator('sna.dgs_render_append_wire_sphere_2bf63', text='Add Wire Sphere', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'noun-sphere-7915480-FFFFFF.svg')), emboss=True, depress=False)
     op = col_4F908.operator('sna.dgs_render_append_wire_cube_56e0f', text='Add Wire Cube', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'noun-cube-7915485-FFFFFF.svg')), emboss=True, depress=False)

--- a/src/append_wire_sphere.py
+++ b/src/append_wire_sphere.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Append_Wire_Sphere_2Bf63(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         if 'EDIT_MESH'==bpy.context.mode:

--- a/src/apply_3dgs_tranforms.py
+++ b/src/apply_3dgs_tranforms.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Apply_3Dgs_Tranforms_5B665(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         target_obj_name = bpy.context.view_layer.objects.active.name
@@ -29,15 +29,6 @@ class SNA_OT_Dgs_Render_Apply_3Dgs_Tranforms_5B665(bpy.types.Operator):
     def draw(self, context):
         layout = self.layout
         box_84D03 = layout.box()
-        box_84D03.alert = False
-        box_84D03.enabled = True
-        box_84D03.active = True
-        box_84D03.use_property_split = False
-        box_84D03.use_property_decorate = False
-        box_84D03.alignment = 'Expand'.upper()
-        box_84D03.scale_x = 1.0
-        box_84D03.scale_y = 1.0
-        if not True: box_84D03.operator_context = "EXEC_DEFAULT"
         box_84D03.prop(self, 'sna_apply_location', text='Apply Location', icon_value=0, emboss=True)
 
     def invoke(self, context, event):

--- a/src/apply_animate_modifier.py
+++ b/src/apply_animate_modifier.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Apply_Animate_Modifier_3938E(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Animate_GN']['Socket_35'] = True

--- a/src/apply_armature_pose_as_rest_pose.py
+++ b/src/apply_armature_pose_as_rest_pose.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Apply_Armature_Pose_As_Rest_Pose_A8C68(bpy.types.Operato
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         """Bake an armature's current pose into the rest pose without losing animation.

--- a/src/apply_light_data.py
+++ b/src/apply_light_data.py
@@ -17,9 +17,9 @@ class SNA_OT_Dgs_Render_Apply_Light_Data_6C5Ad(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         sna_relight2_3_commit_proxy_relight_to_3dgs_6E60F()

--- a/src/apply_modifier.py
+++ b/src/apply_modifier.py
@@ -17,9 +17,9 @@ class SNA_OT_Dgs_Render_Apply_Modifier_0F5F2(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         object_name = self.sna_target_object

--- a/src/attribute_adjust_properties.py
+++ b/src/attribute_adjust_properties.py
@@ -9,36 +9,10 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_attribute_adjust_properties_2C323(layout_function, ):
     box_C40B6 = layout_function.box()
-    box_C40B6.alert = False
-    box_C40B6.enabled = True
-    box_C40B6.active = True
-    box_C40B6.use_property_split = False
-    box_C40B6.use_property_decorate = False
-    box_C40B6.alignment = 'Expand'.upper()
-    box_C40B6.scale_x = 1.0
-    box_C40B6.scale_y = 1.0
-    if not True: box_C40B6.operator_context = "EXEC_DEFAULT"
     split_B43D4 = box_C40B6.split(factor=0.5, align=False)
-    split_B43D4.alert = False
-    split_B43D4.enabled = True
-    split_B43D4.active = True
-    split_B43D4.use_property_split = False
-    split_B43D4.use_property_decorate = False
-    split_B43D4.scale_x = 1.0
-    split_B43D4.scale_y = 1.0
-    split_B43D4.alignment = 'Expand'.upper()
-    if not True: split_B43D4.operator_context = "EXEC_DEFAULT"
     split_B43D4.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], 'show_viewport', text='Adjust Attributes', icon_value=0, emboss=True, toggle=True)
     row_3EABC = split_B43D4.row(heading='', align=True)
-    row_3EABC.alert = False
-    row_3EABC.enabled = True
-    row_3EABC.active = True
-    row_3EABC.use_property_split = False
-    row_3EABC.use_property_decorate = False
-    row_3EABC.scale_x = 1.0
-    row_3EABC.scale_y = 1.0
     row_3EABC.alignment = 'Right'.upper()
-    row_3EABC.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     row_3EABC.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], 'show_render', text='', icon_value=0, emboss=True, toggle=True)
     op = row_3EABC.operator('sna.dgs_render_apply_modifier_0f5f2', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'check.svg')), emboss=True, depress=False)
     op.sna_target_object = bpy.context.view_layer.objects.active.name
@@ -47,52 +21,16 @@ def sna_attribute_adjust_properties_2C323(layout_function, ):
     op.sna_target_object = bpy.context.view_layer.objects.active.name
     op.sna_target_modifier = 'KIRI_3DGS_Adjust_Attributes_GN'
     box_F28C4 = box_C40B6.box()
-    box_F28C4.alert = False
-    box_F28C4.enabled = True
-    box_F28C4.active = True
-    box_F28C4.use_property_split = False
-    box_F28C4.use_property_decorate = False
-    box_F28C4.alignment = 'Expand'.upper()
-    box_F28C4.scale_x = 1.0
-    box_F28C4.scale_y = 1.0
-    if not True: box_F28C4.operator_context = "EXEC_DEFAULT"
     op = box_F28C4.operator('sna.dgs_render_remove_higher_sh_attributes_cb703', text='Remove Higher SH Attributes', icon_value=0, emboss=True, depress=False)
     col_4C14E = box_C40B6.column(heading='', align=True)
-    col_4C14E.alert = False
-    col_4C14E.enabled = True
-    col_4C14E.active = True
-    col_4C14E.use_property_split = False
-    col_4C14E.use_property_decorate = False
-    col_4C14E.scale_x = 1.0
-    col_4C14E.scale_y = 1.0
-    col_4C14E.alignment = 'Expand'.upper()
-    col_4C14E.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     attr_E874B = '["' + str('Socket_3' + '"]') 
     col_4C14E.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_E874B), text='Scale Attributes', icon_value=0, emboss=True, toggle=False)
     if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN']['Socket_3']:
         col_31C13 = col_4C14E.column(heading='', align=True)
-        col_31C13.alert = False
-        col_31C13.enabled = True
-        col_31C13.active = True
-        col_31C13.use_property_split = False
-        col_31C13.use_property_decorate = False
-        col_31C13.scale_x = 1.0
-        col_31C13.scale_y = 1.0
-        col_31C13.alignment = 'Expand'.upper()
-        col_31C13.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_2C986 = '["' + str('Socket_6' + '"]') 
         col_31C13.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_2C986), text='', icon_value=0, emboss=True, toggle=True)
         if ((bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN']['Socket_6'] == 2) or (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN']['Socket_6'] == 3)):
             box_EE993 = col_31C13.box()
-            box_EE993.alert = False
-            box_EE993.enabled = True
-            box_EE993.active = True
-            box_EE993.use_property_split = False
-            box_EE993.use_property_decorate = False
-            box_EE993.alignment = 'Expand'.upper()
-            box_EE993.scale_x = 1.0
-            box_EE993.scale_y = 1.0
-            if not True: box_EE993.operator_context = "EXEC_DEFAULT"
             box_EE993.label(text='Change values slowly to avoid crashes', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         attr_120DC = '["' + str('Socket_8' + '"]') 
         col_31C13.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_120DC), text='', icon_value=0, emboss=True, toggle=True)
@@ -101,15 +39,6 @@ def sna_attribute_adjust_properties_2C323(layout_function, ):
             col_31C13.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_B4207), text='All Scales', icon_value=0, emboss=True, toggle=True)
         else:
             col_9E5AF = col_31C13.column(heading='', align=False)
-            col_9E5AF.alert = False
-            col_9E5AF.enabled = True
-            col_9E5AF.active = True
-            col_9E5AF.use_property_split = False
-            col_9E5AF.use_property_decorate = False
-            col_9E5AF.scale_x = 1.0
-            col_9E5AF.scale_y = 1.0
-            col_9E5AF.alignment = 'Expand'.upper()
-            col_9E5AF.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_734DA = '["' + str('Socket_10' + '"]') 
             col_9E5AF.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_734DA), text='Scale_0', icon_value=0, emboss=True, toggle=True)
             attr_EAC87 = '["' + str('Socket_9' + '"]') 
@@ -117,120 +46,39 @@ def sna_attribute_adjust_properties_2C323(layout_function, ):
             attr_F45C1 = '["' + str('Socket_7' + '"]') 
             col_9E5AF.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_F45C1), text='Scale_2', icon_value=0, emboss=True, toggle=True)
     col_75DFB = box_C40B6.column(heading='', align=True)
-    col_75DFB.alert = False
-    col_75DFB.enabled = True
-    col_75DFB.active = True
-    col_75DFB.use_property_split = False
-    col_75DFB.use_property_decorate = False
-    col_75DFB.scale_x = 1.0
-    col_75DFB.scale_y = 1.0
-    col_75DFB.alignment = 'Expand'.upper()
-    col_75DFB.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     attr_670D5 = '["' + str('Socket_4' + '"]') 
     col_75DFB.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_670D5), text='Rotation Attributes', icon_value=0, emboss=True, toggle=False)
     if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN']['Socket_4']:
         col_B2D6A = col_75DFB.column(heading='', align=True)
-        col_B2D6A.alert = False
-        col_B2D6A.enabled = True
-        col_B2D6A.active = True
-        col_B2D6A.use_property_split = False
-        col_B2D6A.use_property_decorate = False
-        col_B2D6A.scale_x = 1.0
-        col_B2D6A.scale_y = 1.0
-        col_B2D6A.alignment = 'Expand'.upper()
-        col_B2D6A.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_85A74 = '["' + str('Socket_48' + '"]') 
         col_B2D6A.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_85A74), text='', icon_value=0, emboss=True, toggle=True)
         if (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN']['Socket_48'] == 0):
             col_125B4 = col_B2D6A.column(heading='', align=True)
-            col_125B4.alert = False
-            col_125B4.enabled = True
-            col_125B4.active = True
-            col_125B4.use_property_split = False
-            col_125B4.use_property_decorate = False
-            col_125B4.scale_x = 1.0
-            col_125B4.scale_y = 1.0
-            col_125B4.alignment = 'Expand'.upper()
-            col_125B4.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_389BC = '["' + str('Socket_21' + '"]') 
             col_125B4.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_389BC), text='Rotation', icon_value=0, emboss=True, toggle=True)
         else:
             col_F40AA = col_B2D6A.column(heading='', align=True)
-            col_F40AA.alert = False
-            col_F40AA.enabled = True
-            col_F40AA.active = True
-            col_F40AA.use_property_split = False
-            col_F40AA.use_property_decorate = False
-            col_F40AA.scale_x = 1.0
-            col_F40AA.scale_y = 1.0
-            col_F40AA.alignment = 'Expand'.upper()
-            col_F40AA.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_6DFDA = '["' + str('Socket_51' + '"]') 
             col_F40AA.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_6DFDA), text='Axis', icon_value=0, emboss=True, toggle=True)
             attr_E15B5 = '["' + str('Socket_50' + '"]') 
             col_F40AA.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_E15B5), text='Target', icon_value=0, emboss=True, toggle=True)
     col_0C20D = box_C40B6.column(heading='', align=True)
-    col_0C20D.alert = False
-    col_0C20D.enabled = True
-    col_0C20D.active = True
-    col_0C20D.use_property_split = False
-    col_0C20D.use_property_decorate = False
-    col_0C20D.scale_x = 1.0
-    col_0C20D.scale_y = 1.0
-    col_0C20D.alignment = 'Expand'.upper()
-    col_0C20D.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     attr_D2232 = '["' + str('Socket_54' + '"]') 
     col_0C20D.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_D2232), text='Opacity Attributes', icon_value=0, emboss=True, toggle=False)
     if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN']['Socket_54']:
         col_F6DA7 = col_0C20D.column(heading='', align=True)
-        col_F6DA7.alert = False
-        col_F6DA7.enabled = True
-        col_F6DA7.active = True
-        col_F6DA7.use_property_split = False
-        col_F6DA7.use_property_decorate = False
-        col_F6DA7.scale_x = 1.0
-        col_F6DA7.scale_y = 1.0
-        col_F6DA7.alignment = 'Expand'.upper()
-        col_F6DA7.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_7BD79 = '["' + str('Socket_52' + '"]') 
         col_F6DA7.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_7BD79), text='', icon_value=0, emboss=True, toggle=True)
         if ((bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN']['Socket_52'] == 2) or (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN']['Socket_52'] == 3)):
             box_E8A8F = col_F6DA7.box()
-            box_E8A8F.alert = False
-            box_E8A8F.enabled = True
-            box_E8A8F.active = True
-            box_E8A8F.use_property_split = False
-            box_E8A8F.use_property_decorate = False
-            box_E8A8F.alignment = 'Expand'.upper()
-            box_E8A8F.scale_x = 1.0
-            box_E8A8F.scale_y = 1.0
-            if not True: box_E8A8F.operator_context = "EXEC_DEFAULT"
             box_E8A8F.label(text='Change values slowly to avoid crashes', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         attr_20728 = '["' + str('Socket_55' + '"]') 
         col_F6DA7.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_20728), text='All Scales', icon_value=0, emboss=True, toggle=True)
     col_CADFD = box_C40B6.column(heading='', align=True)
-    col_CADFD.alert = False
-    col_CADFD.enabled = True
-    col_CADFD.active = True
-    col_CADFD.use_property_split = False
-    col_CADFD.use_property_decorate = False
-    col_CADFD.scale_x = 1.0
-    col_CADFD.scale_y = 1.0
-    col_CADFD.alignment = 'Expand'.upper()
-    col_CADFD.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     attr_9A41E = '["' + str('Socket_23' + '"]') 
     col_CADFD.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_9A41E), text='SH 1 Attributes', icon_value=0, emboss=True, toggle=False)
     if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN']['Socket_23']:
         col_83806 = col_CADFD.column(heading='', align=True)
-        col_83806.alert = False
-        col_83806.enabled = True
-        col_83806.active = True
-        col_83806.use_property_split = True
-        col_83806.use_property_decorate = False
-        col_83806.scale_x = 1.0
-        col_83806.scale_y = 1.0
-        col_83806.alignment = 'Expand'.upper()
-        col_83806.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_31D21 = '["' + str('Socket_24' + '"]') 
         col_83806.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_31D21), text='Red Adjust Type', icon_value=0, emboss=True, expand=False, toggle=True)
         attr_0574B = '["' + str('Socket_25' + '"]') 
@@ -244,28 +92,10 @@ def sna_attribute_adjust_properties_2C323(layout_function, ):
         attr_955F9 = '["' + str('Socket_33' + '"]') 
         col_83806.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_955F9), text='', icon_value=0, emboss=True, toggle=True)
     col_F20A7 = box_C40B6.column(heading='', align=True)
-    col_F20A7.alert = False
-    col_F20A7.enabled = True
-    col_F20A7.active = True
-    col_F20A7.use_property_split = False
-    col_F20A7.use_property_decorate = False
-    col_F20A7.scale_x = 1.0
-    col_F20A7.scale_y = 1.0
-    col_F20A7.alignment = 'Expand'.upper()
-    col_F20A7.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     attr_86E8C = '["' + str('Socket_34' + '"]') 
     col_F20A7.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_86E8C), text='SH 2 Attributes', icon_value=0, emboss=True, toggle=False)
     if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN']['Socket_34']:
         col_41831 = col_F20A7.column(heading='', align=True)
-        col_41831.alert = False
-        col_41831.enabled = True
-        col_41831.active = True
-        col_41831.use_property_split = True
-        col_41831.use_property_decorate = False
-        col_41831.scale_x = 1.0
-        col_41831.scale_y = 1.0
-        col_41831.alignment = 'Expand'.upper()
-        col_41831.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_EE5FE = '["' + str('Socket_35' + '"]') 
         col_41831.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_EE5FE), text='Red Adjust Type', icon_value=0, emboss=True, expand=False, toggle=True)
         attr_380DC = '["' + str('Socket_36' + '"]') 
@@ -279,28 +109,10 @@ def sna_attribute_adjust_properties_2C323(layout_function, ):
         attr_75F7B = '["' + str('Socket_43' + '"]') 
         col_41831.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_75F7B), text='', icon_value=0, emboss=True, toggle=True)
     col_1D52E = box_C40B6.column(heading='', align=True)
-    col_1D52E.alert = False
-    col_1D52E.enabled = True
-    col_1D52E.active = True
-    col_1D52E.use_property_split = False
-    col_1D52E.use_property_decorate = False
-    col_1D52E.scale_x = 1.0
-    col_1D52E.scale_y = 1.0
-    col_1D52E.alignment = 'Expand'.upper()
-    col_1D52E.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     attr_73E08 = '["' + str('Socket_39' + '"]') 
     col_1D52E.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_73E08), text='SH 3 Attributes', icon_value=0, emboss=True, toggle=False)
     if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN']['Socket_39']:
         col_9E249 = col_1D52E.column(heading='', align=True)
-        col_9E249.alert = False
-        col_9E249.enabled = True
-        col_9E249.active = True
-        col_9E249.use_property_split = True
-        col_9E249.use_property_decorate = False
-        col_9E249.scale_x = 1.0
-        col_9E249.scale_y = 1.0
-        col_9E249.alignment = 'Expand'.upper()
-        col_9E249.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_E35A2 = '["' + str('Socket_40' + '"]') 
         col_9E249.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Attributes_GN'], attr_E35A2), text='Red Adjust Type', icon_value=0, emboss=True, expand=False, toggle=True)
         attr_4369F = '["' + str('Socket_41' + '"]') 

--- a/src/attribute_select.py
+++ b/src/attribute_select.py
@@ -30,9 +30,9 @@ class SNA_OT_Dgs_Render_Attribute_Select_51C86(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         TARGET_OBJ = bpy.context.view_layer.objects.active
@@ -220,74 +220,20 @@ class SNA_OT_Dgs_Render_Attribute_Select_51C86(bpy.types.Operator):
         layout = self.layout
         if bpy.context.scene.sna_dgs_scene_properties.select_attribute_type == "SCALE":
             col_94F1A = layout.column(heading='', align=False)
-            col_94F1A.alert = False
-            col_94F1A.enabled = True
-            col_94F1A.active = True
-            col_94F1A.use_property_split = False
-            col_94F1A.use_property_decorate = False
-            col_94F1A.scale_x = 1.0
-            col_94F1A.scale_y = 1.0
-            col_94F1A.alignment = 'Expand'.upper()
-            col_94F1A.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             col_94F1A.prop(self, 'sna_scale_target_attr', text=self.sna_scale_target_attr, icon_value=0, emboss=True, expand=True)
             col_94F1A.prop(self, 'sna_scale_factor', text='Factor', icon_value=0, emboss=True, expand=False)
             row_0FEBA = col_94F1A.row(heading='', align=False)
-            row_0FEBA.alert = False
-            row_0FEBA.enabled = True
-            row_0FEBA.active = True
-            row_0FEBA.use_property_split = False
-            row_0FEBA.use_property_decorate = False
-            row_0FEBA.scale_x = 1.0
-            row_0FEBA.scale_y = 1.0
-            row_0FEBA.alignment = 'Expand'.upper()
-            row_0FEBA.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             row_0FEBA.prop(self, 'sna_scale_compare', text=self.sna_scale_compare, icon_value=0, emboss=True, expand=True)
         elif bpy.context.scene.sna_dgs_scene_properties.select_attribute_type == "ROT":
             col_50BE3 = layout.column(heading='', align=False)
-            col_50BE3.alert = False
-            col_50BE3.enabled = True
-            col_50BE3.active = True
-            col_50BE3.use_property_split = False
-            col_50BE3.use_property_decorate = False
-            col_50BE3.scale_x = 1.0
-            col_50BE3.scale_y = 1.0
-            col_50BE3.alignment = 'Expand'.upper()
-            col_50BE3.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             col_50BE3.prop(self, 'sna_rot_target_euler', text='Target Rotation', icon_value=0, emboss=True)
             col_50BE3.prop(self, 'sna_rot_tolerance_deg', text='Tolerance', icon_value=0, emboss=True, expand=False)
             row_9826B = col_50BE3.row(heading='', align=False)
-            row_9826B.alert = False
-            row_9826B.enabled = True
-            row_9826B.active = True
-            row_9826B.use_property_split = False
-            row_9826B.use_property_decorate = False
-            row_9826B.scale_x = 1.0
-            row_9826B.scale_y = 1.0
-            row_9826B.alignment = 'Expand'.upper()
-            row_9826B.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             row_9826B.prop(self, 'sna_rot_compare', text=self.sna_rot_compare, icon_value=0, emboss=True, expand=True)
         elif bpy.context.scene.sna_dgs_scene_properties.select_attribute_type == "STRETCH":
             col_0EDB7 = layout.column(heading='', align=False)
-            col_0EDB7.alert = False
-            col_0EDB7.enabled = True
-            col_0EDB7.active = True
-            col_0EDB7.use_property_split = False
-            col_0EDB7.use_property_decorate = False
-            col_0EDB7.scale_x = 1.0
-            col_0EDB7.scale_y = 1.0
-            col_0EDB7.alignment = 'Expand'.upper()
-            col_0EDB7.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             col_0EDB7.prop(self, 'sna_scale_factor', text='Factor', icon_value=0, emboss=True, expand=False)
             row_1AE6E = col_0EDB7.row(heading='', align=False)
-            row_1AE6E.alert = False
-            row_1AE6E.enabled = True
-            row_1AE6E.active = True
-            row_1AE6E.use_property_split = False
-            row_1AE6E.use_property_decorate = False
-            row_1AE6E.scale_x = 1.0
-            row_1AE6E.scale_y = 1.0
-            row_1AE6E.alignment = 'Expand'.upper()
-            row_1AE6E.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             row_1AE6E.prop(self, 'sna_scale_compare', text=self.sna_scale_compare, icon_value=0, emboss=True, expand=True)
         else:
             pass

--- a/src/auto_generate_crop_object.py
+++ b/src/auto_generate_crop_object.py
@@ -23,9 +23,9 @@ class SNA_OT_Dgs_Render_Auto_Generate_Crop_Object_F20D5(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         OPEN3D_AVAILABLE = None
@@ -816,47 +816,11 @@ class SNA_OT_Dgs_Render_Auto_Generate_Crop_Object_F20D5(bpy.types.Operator):
     def draw(self, context):
         layout = self.layout
         col_AFE45 = layout.column(heading='', align=False)
-        col_AFE45.alert = False
-        col_AFE45.enabled = True
-        col_AFE45.active = True
-        col_AFE45.use_property_split = False
-        col_AFE45.use_property_decorate = False
-        col_AFE45.scale_x = 1.0
-        col_AFE45.scale_y = 1.0
-        col_AFE45.alignment = 'Expand'.upper()
-        col_AFE45.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         box_E9B63 = col_AFE45.box()
-        box_E9B63.alert = False
-        box_E9B63.enabled = True
-        box_E9B63.active = True
-        box_E9B63.use_property_split = False
-        box_E9B63.use_property_decorate = False
-        box_E9B63.alignment = 'Expand'.upper()
-        box_E9B63.scale_x = 1.0
-        box_E9B63.scale_y = 1.0
-        if not True: box_E9B63.operator_context = "EXEC_DEFAULT"
         box_E9B63.label(text="There is no 'one size fits all' setting.", icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_E9B63.label(text='You may need to play with different values.', icon_value=0)
         box_AC64A = col_AFE45.box()
-        box_AC64A.alert = False
-        box_AC64A.enabled = True
-        box_AC64A.active = True
-        box_AC64A.use_property_split = False
-        box_AC64A.use_property_decorate = False
-        box_AC64A.alignment = 'Expand'.upper()
-        box_AC64A.scale_x = 1.0
-        box_AC64A.scale_y = 1.0
-        if not True: box_AC64A.operator_context = "EXEC_DEFAULT"
         row_A0C33 = box_AC64A.row(heading='', align=False)
-        row_A0C33.alert = False
-        row_A0C33.enabled = True
-        row_A0C33.active = True
-        row_A0C33.use_property_split = False
-        row_A0C33.use_property_decorate = False
-        row_A0C33.scale_x = 1.0
-        row_A0C33.scale_y = 1.0
-        row_A0C33.alignment = 'Expand'.upper()
-        row_A0C33.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_A0C33.label(text='Mode', icon_value=0)
         row_A0C33.prop(self, 'sna_filter_mode', text=self.sna_filter_mode, icon_value=0, emboss=True, expand=True)
         box_AC64A.prop(self, 'sna_filter_epsilon', text='Filter Epsilon', icon_value=0, emboss=True, slider=True)

--- a/src/auto_set_up_camera_cull_properties.py
+++ b/src/auto_set_up_camera_cull_properties.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Auto_Set_Up_Camera_Cull_Properties_Aef48(bpy.types.Opera
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Camera_Cull_GN']['Socket_2'] = bpy.context.scene.render.resolution_x

--- a/src/bake_frames_to_cache.py
+++ b/src/bake_frames_to_cache.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Bake_Frames_To_Cache_90885(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         proxy_binding_cache_root = bpy.context.preferences.addons[__package__].preferences.sna_cache_file_directory

--- a/src/bind_and_misc_tools.py
+++ b/src/bind_and_misc_tools.py
@@ -9,28 +9,11 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_bind_and_misc_tools_C36C1(layout_function, ):
     box_D0924 = layout_function.box()
-    box_D0924.alert = False
-    box_D0924.enabled = True
-    box_D0924.active = True
-    box_D0924.use_property_split = False
-    box_D0924.use_property_decorate = False
-    box_D0924.alignment = 'Expand'.upper()
-    box_D0924.scale_x = 1.0
-    box_D0924.scale_y = 1.0
-    if not True: box_D0924.operator_context = "EXEC_DEFAULT"
     box_D0924.label(text='Bind', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
     box_D0924.prop(bpy.context.scene.sna_dgs_scene_properties, 'rig_bind_method', text='', icon_value=0, emboss=True)
     if (bpy.context.scene.sna_dgs_scene_properties.rig_bind_method == 'Hybrid'):
         box_D0924.prop(bpy.context.scene.sna_dgs_scene_properties, 'rig_surface_dist_factor', text='Hybrid Distance Factor', icon_value=0, emboss=True)
     box_D0924.prop(bpy.context.scene.sna_dgs_scene_properties, 'rig_bind_samples', text='Bind Samples', icon_value=0, emboss=True)
     col_A97C8 = box_D0924.column(heading='', align=False)
-    col_A97C8.alert = False
-    col_A97C8.enabled = True
-    col_A97C8.active = True
-    col_A97C8.use_property_split = False
-    col_A97C8.use_property_decorate = False
-    col_A97C8.scale_x = 1.0
     col_A97C8.scale_y = 2.0
-    col_A97C8.alignment = 'Expand'.upper()
-    col_A97C8.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     op = col_A97C8.operator('sna.dgs_render_bind_to_proxy_mesh_6c58f', text='Bind to Proxy Mesh', icon_value=0, emboss=True, depress=False)

--- a/src/bind_to_proxy_mesh.py
+++ b/src/bind_to_proxy_mesh.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Bind_To_Proxy_Mesh_6C58F(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         active_obj = bpy.context.view_layer.objects.active

--- a/src/build_light_data.py
+++ b/src/build_light_data.py
@@ -17,9 +17,9 @@ class SNA_OT_Dgs_Render_Build_Light_Data_Ab375(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         sna_relight2_1_build_base_color_from_f_dc_BAE18()

--- a/src/camera_cull.py
+++ b/src/camera_cull.py
@@ -10,36 +10,10 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_camera_cull_8069C(layout_function, ):
     if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Camera_Cull_GN' in bpy.context.view_layer.objects.active.modifiers):
         box_7279D = layout_function.box()
-        box_7279D.alert = False
-        box_7279D.enabled = True
-        box_7279D.active = True
-        box_7279D.use_property_split = False
-        box_7279D.use_property_decorate = False
-        box_7279D.alignment = 'Expand'.upper()
-        box_7279D.scale_x = 1.0
-        box_7279D.scale_y = 1.0
-        if not True: box_7279D.operator_context = "EXEC_DEFAULT"
         split_D5A9B = box_7279D.split(factor=0.5, align=False)
-        split_D5A9B.alert = False
-        split_D5A9B.enabled = True
-        split_D5A9B.active = True
-        split_D5A9B.use_property_split = False
-        split_D5A9B.use_property_decorate = False
-        split_D5A9B.scale_x = 1.0
-        split_D5A9B.scale_y = 1.0
-        split_D5A9B.alignment = 'Expand'.upper()
-        if not True: split_D5A9B.operator_context = "EXEC_DEFAULT"
         split_D5A9B.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Camera_Cull_GN'], 'show_viewport', text='Camera Cull', icon_value=0, emboss=True, toggle=True)
         row_F9B38 = split_D5A9B.row(heading='', align=True)
-        row_F9B38.alert = False
-        row_F9B38.enabled = True
-        row_F9B38.active = True
-        row_F9B38.use_property_split = False
-        row_F9B38.use_property_decorate = False
-        row_F9B38.scale_x = 1.0
-        row_F9B38.scale_y = 1.0
         row_F9B38.alignment = 'Right'.upper()
-        row_F9B38.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_F9B38.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Camera_Cull_GN'], 'show_render', text='', icon_value=0, emboss=True, toggle=True)
         op = row_F9B38.operator('sna.dgs_render_apply_modifier_0f5f2', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'check.svg')), emboss=True, depress=False)
         op.sna_target_object = bpy.context.view_layer.objects.active.name
@@ -49,27 +23,9 @@ def sna_camera_cull_8069C(layout_function, ):
         op.sna_target_modifier = 'KIRI_3DGS_Camera_Cull_GN'
         if (bpy.context.scene.camera == None):
             box_07B9F = box_7279D.box()
-            box_07B9F.alert = False
-            box_07B9F.enabled = True
-            box_07B9F.active = True
-            box_07B9F.use_property_split = False
-            box_07B9F.use_property_decorate = False
-            box_07B9F.alignment = 'Expand'.upper()
-            box_07B9F.scale_x = 1.0
-            box_07B9F.scale_y = 1.0
-            if not True: box_07B9F.operator_context = "EXEC_DEFAULT"
             box_07B9F.label(text='No Active Camera In Scene', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         else:
             col_A2A21 = box_7279D.column(heading='', align=True)
-            col_A2A21.alert = False
-            col_A2A21.enabled = True
-            col_A2A21.active = True
-            col_A2A21.use_property_split = False
-            col_A2A21.use_property_decorate = False
-            col_A2A21.scale_x = 1.0
-            col_A2A21.scale_y = 1.0
-            col_A2A21.alignment = 'Expand'.upper()
-            col_A2A21.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             op = col_A2A21.operator('sna.dgs_render_auto_set_up_camera_cull_properties_aef48', text='Auto Set Up', icon_value=0, emboss=True, depress=False)
             attr_31E14 = '["' + str('Socket_2' + '"]') 
             col_A2A21.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Camera_Cull_GN'], attr_31E14), text='X Resolution', icon_value=0, emboss=True)
@@ -87,25 +43,8 @@ def sna_camera_cull_8069C(layout_function, ):
             col_A2A21.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Camera_Cull_GN'], attr_45049), text='Further Than', icon_value=0, emboss=True)
     else:
         box_05674 = layout_function.box()
-        box_05674.alert = False
         box_05674.enabled = 'OBJECT'==bpy.context.mode
-        box_05674.active = True
-        box_05674.use_property_split = False
-        box_05674.use_property_decorate = False
-        box_05674.alignment = 'Expand'.upper()
-        box_05674.scale_x = 1.0
-        box_05674.scale_y = 1.0
-        if not True: box_05674.operator_context = "EXEC_DEFAULT"
         row_B29D4 = box_05674.row(heading='', align=False)
-        row_B29D4.alert = False
-        row_B29D4.enabled = True
-        row_B29D4.active = True
-        row_B29D4.use_property_split = False
-        row_B29D4.use_property_decorate = False
-        row_B29D4.scale_x = 1.0
-        row_B29D4.scale_y = 1.0
-        row_B29D4.alignment = 'Expand'.upper()
-        row_B29D4.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_B29D4.label(text='Camera Cull', icon_value=0)
         op = row_B29D4.operator('sna.dgs_render_append_geometry_node_modifier_c2492', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'plus-circle.svg')), emboss=True, depress=False)
         op.sna_node_group_name = 'KIRI_3DGS_Camera_Cull_GN'

--- a/src/clean_up_scene_80052.py
+++ b/src/clean_up_scene_80052.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Clean_Up_Scene_80052(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         sna_clean_up_scene_5F1F1(bpy.context.scene.sna_dgs_scene_properties.r2_clear_empties)

--- a/src/clear_rig_cache.py
+++ b/src/clear_rig_cache.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Clear_Rig_Cache_F38Be(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         proxy_binding_cache_root = bpy.context.preferences.addons[__package__].preferences.sna_cache_file_directory

--- a/src/colour_edit.py
+++ b/src/colour_edit.py
@@ -10,36 +10,10 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_colour_edit_37123(layout_function, ):
     if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Colour_Edit_GN' in bpy.context.view_layer.objects.active.modifiers):
         box_1A729 = layout_function.box()
-        box_1A729.alert = False
-        box_1A729.enabled = True
-        box_1A729.active = True
-        box_1A729.use_property_split = False
-        box_1A729.use_property_decorate = False
-        box_1A729.alignment = 'Expand'.upper()
-        box_1A729.scale_x = 1.0
-        box_1A729.scale_y = 1.0
-        if not True: box_1A729.operator_context = "EXEC_DEFAULT"
         split_A4B39 = box_1A729.split(factor=0.5, align=False)
-        split_A4B39.alert = False
-        split_A4B39.enabled = True
-        split_A4B39.active = True
-        split_A4B39.use_property_split = False
-        split_A4B39.use_property_decorate = False
-        split_A4B39.scale_x = 1.0
-        split_A4B39.scale_y = 1.0
-        split_A4B39.alignment = 'Expand'.upper()
-        if not True: split_A4B39.operator_context = "EXEC_DEFAULT"
         split_A4B39.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Colour_Edit_GN'], 'show_viewport', text='Colour Edit', icon_value=0, emboss=True, toggle=True)
         row_7335E = split_A4B39.row(heading='', align=True)
-        row_7335E.alert = False
-        row_7335E.enabled = True
-        row_7335E.active = True
-        row_7335E.use_property_split = False
-        row_7335E.use_property_decorate = False
-        row_7335E.scale_x = 1.0
-        row_7335E.scale_y = 1.0
         row_7335E.alignment = 'Right'.upper()
-        row_7335E.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_7335E.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Colour_Edit_GN'], 'show_render', text='', icon_value=0, emboss=True, toggle=True)
         op = row_7335E.operator('sna.dgs_render_apply_modifier_0f5f2', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'check.svg')), emboss=True, depress=False)
         op.sna_target_object = bpy.context.view_layer.objects.active.name
@@ -48,30 +22,12 @@ def sna_colour_edit_37123(layout_function, ):
         op.sna_target_object = bpy.context.view_layer.objects.active.name
         op.sna_target_modifier = 'KIRI_3DGS_Colour_Edit_GN'
         col_836C0 = box_1A729.column(heading='', align=True)
-        col_836C0.alert = False
-        col_836C0.enabled = True
-        col_836C0.active = True
-        col_836C0.use_property_split = False
-        col_836C0.use_property_decorate = False
-        col_836C0.scale_x = 1.0
-        col_836C0.scale_y = 1.0
-        col_836C0.alignment = 'Expand'.upper()
-        col_836C0.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_64F25 = '["' + str('Socket_4' + '"]') 
         col_836C0.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Colour_Edit_GN'], attr_64F25), text='', icon_value=0, emboss=True)
         attr_F9B60 = '["' + str('Socket_2' + '"]') 
         col_836C0.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Colour_Edit_GN'], attr_F9B60), text='', icon_value=0, emboss=True)
         if ((bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Colour_Edit_GN']['Socket_4'] == 0) or (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Colour_Edit_GN']['Socket_4'] == 1)):
             col_A8E1B = col_836C0.column(heading='', align=False)
-            col_A8E1B.alert = False
-            col_A8E1B.enabled = True
-            col_A8E1B.active = True
-            col_A8E1B.use_property_split = False
-            col_A8E1B.use_property_decorate = False
-            col_A8E1B.scale_x = 1.0
-            col_A8E1B.scale_y = 1.0
-            col_A8E1B.alignment = 'Expand'.upper()
-            col_A8E1B.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_10C7C = '["' + str('Socket_3' + '"]') 
             col_A8E1B.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Colour_Edit_GN'], attr_10C7C), text='Hue Threshold', icon_value=0, emboss=True)
             attr_8DE4C = '["' + str('Socket_6' + '"]') 
@@ -79,28 +35,10 @@ def sna_colour_edit_37123(layout_function, ):
             attr_E480B = '["' + str('Socket_7' + '"]') 
             col_A8E1B.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Colour_Edit_GN'], attr_E480B), text='Value Threshold', icon_value=0, emboss=True)
         col_85E9D = box_1A729.column(heading='', align=False)
-        col_85E9D.alert = False
-        col_85E9D.enabled = True
-        col_85E9D.active = True
-        col_85E9D.use_property_split = False
-        col_85E9D.use_property_decorate = False
-        col_85E9D.scale_x = 1.0
-        col_85E9D.scale_y = 1.0
-        col_85E9D.alignment = 'Expand'.upper()
-        col_85E9D.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_7F527 = '["' + str('Socket_11' + '"]') 
         col_85E9D.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Colour_Edit_GN'], attr_7F527), text='Colour Edit Masking', icon_value=0, emboss=True, toggle=True)
         if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Colour_Edit_GN']['Socket_11']:
             col_758DD = col_85E9D.column(heading='', align=False)
-            col_758DD.alert = False
-            col_758DD.enabled = True
-            col_758DD.active = True
-            col_758DD.use_property_split = False
-            col_758DD.use_property_decorate = False
-            col_758DD.scale_x = 1.0
-            col_758DD.scale_y = 1.0
-            col_758DD.alignment = 'Expand'.upper()
-            col_758DD.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_C4FB4 = '["' + str('Socket_8' + '"]') 
             col_758DD.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Colour_Edit_GN'], attr_C4FB4), text='', icon_value=0, emboss=True, toggle=True)
             attr_0B7C4 = '["' + str('Socket_9' + '"]') 
@@ -110,25 +48,8 @@ def sna_colour_edit_37123(layout_function, ):
                 col_758DD.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Colour_Edit_GN'], attr_4B792), text='Distance Threshold', icon_value=0, emboss=True, toggle=True)
     else:
         box_2F40B = layout_function.box()
-        box_2F40B.alert = False
         box_2F40B.enabled = 'OBJECT'==bpy.context.mode
-        box_2F40B.active = True
-        box_2F40B.use_property_split = False
-        box_2F40B.use_property_decorate = False
-        box_2F40B.alignment = 'Expand'.upper()
-        box_2F40B.scale_x = 1.0
-        box_2F40B.scale_y = 1.0
-        if not True: box_2F40B.operator_context = "EXEC_DEFAULT"
         row_78C95 = box_2F40B.row(heading='', align=False)
-        row_78C95.alert = False
-        row_78C95.enabled = True
-        row_78C95.active = True
-        row_78C95.use_property_split = False
-        row_78C95.use_property_decorate = False
-        row_78C95.scale_x = 1.0
-        row_78C95.scale_y = 1.0
-        row_78C95.alignment = 'Expand'.upper()
-        row_78C95.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_78C95.label(text='Color Edit', icon_value=0)
         op = row_78C95.operator('sna.dgs_render_append_geometry_node_modifier_c2492', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'plus-circle.svg')), emboss=True, depress=False)
         op.sna_node_group_name = 'KIRI_3DGS_Colour_Edit_GN'

--- a/src/colour_function_interface.py
+++ b/src/colour_function_interface.py
@@ -14,50 +14,14 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_colour_function_interface_3A6A5(layout_function, ):
     col_EB8EB = layout_function.column(heading='', align=False)
-    col_EB8EB.alert = False
-    col_EB8EB.enabled = True
-    col_EB8EB.active = True
-    col_EB8EB.use_property_split = False
-    col_EB8EB.use_property_decorate = False
-    col_EB8EB.scale_x = 1.0
-    col_EB8EB.scale_y = 1.0
-    col_EB8EB.alignment = 'Expand'.upper()
-    col_EB8EB.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     box_E0430 = col_EB8EB.box()
-    box_E0430.alert = False
-    box_E0430.enabled = True
-    box_E0430.active = True
-    box_E0430.use_property_split = False
-    box_E0430.use_property_decorate = False
-    box_E0430.alignment = 'Expand'.upper()
-    box_E0430.scale_x = 1.0
-    box_E0430.scale_y = 1.0
-    if not True: box_E0430.operator_context = "EXEC_DEFAULT"
     attr_17916 = '["' + str('Socket_54' + '"]') 
     box_E0430.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_17916), text='Shadeless', icon_value=0, emboss=True, toggle=False)
     attr_787E3 = '["' + str('Socket_71' + '"]') 
     box_E0430.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_787E3), text='Create Extra Attributes', icon_value=0, emboss=True, toggle=False)
     col_EB8EB.separator(factor=1.0)
     box_47A8F = col_EB8EB.box()
-    box_47A8F.alert = False
-    box_47A8F.enabled = True
-    box_47A8F.active = True
-    box_47A8F.use_property_split = False
-    box_47A8F.use_property_decorate = False
-    box_47A8F.alignment = 'Expand'.upper()
-    box_47A8F.scale_x = 1.0
-    box_47A8F.scale_y = 1.0
-    if not True: box_47A8F.operator_context = "EXEC_DEFAULT"
     col_89B6E = box_47A8F.column(heading='', align=True)
-    col_89B6E.alert = False
-    col_89B6E.enabled = True
-    col_89B6E.active = True
-    col_89B6E.use_property_split = False
-    col_89B6E.use_property_decorate = False
-    col_89B6E.scale_x = 1.0
-    col_89B6E.scale_y = 1.0
-    col_89B6E.alignment = 'Expand'.upper()
-    col_89B6E.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     attr_032D8 = '["' + str('Socket_6' + '"]') 
     col_89B6E.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_032D8), text='Brightness', icon_value=0, emboss=True)
     attr_18662 = '["' + str('Socket_2' + '"]') 
@@ -68,15 +32,6 @@ def sna_colour_function_interface_3A6A5(layout_function, ):
     col_89B6E.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_9DF33), text='Saturation', icon_value=0, emboss=True)
     col_EB8EB.separator(factor=1.0)
     box_A85FA = col_EB8EB.box()
-    box_A85FA.alert = False
-    box_A85FA.enabled = True
-    box_A85FA.active = True
-    box_A85FA.use_property_split = False
-    box_A85FA.use_property_decorate = False
-    box_A85FA.alignment = 'Expand'.upper()
-    box_A85FA.scale_x = 1.0
-    box_A85FA.scale_y = 1.0
-    if not True: box_A85FA.operator_context = "EXEC_DEFAULT"
     box_A85FA.label(text='Active Colour Menu', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
     box_A85FA.prop(bpy.context.scene.sna_dgs_scene_properties, 'shading_menu', text=bpy.context.scene.sna_dgs_scene_properties.shading_menu, icon_value=0, emboss=True, expand=True)
     col_EB8EB.separator(factor=1.0)

--- a/src/convert_face_3dgs_to_vert_3dgs.py
+++ b/src/convert_face_3dgs_to_vert_3dgs.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Convert_Face_3Dgs_To_Vert_3Dgs_Fc49C(bpy.types.Operator)
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         target_obj_name = bpy.context.view_layer.objects.active.name

--- a/src/convert_to_rough_mesh.py
+++ b/src/convert_to_rough_mesh.py
@@ -10,36 +10,10 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_convert_to_rough_mesh_BF549(layout_function, ):
     if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Convert_To_Rough_Mesh_GN' in bpy.context.view_layer.objects.active.modifiers):
         box_F10CF = layout_function.box()
-        box_F10CF.alert = False
-        box_F10CF.enabled = True
-        box_F10CF.active = True
-        box_F10CF.use_property_split = False
-        box_F10CF.use_property_decorate = False
-        box_F10CF.alignment = 'Expand'.upper()
-        box_F10CF.scale_x = 1.0
-        box_F10CF.scale_y = 1.0
-        if not True: box_F10CF.operator_context = "EXEC_DEFAULT"
         split_CD9F1 = box_F10CF.split(factor=0.5, align=False)
-        split_CD9F1.alert = False
-        split_CD9F1.enabled = True
-        split_CD9F1.active = True
-        split_CD9F1.use_property_split = False
-        split_CD9F1.use_property_decorate = False
-        split_CD9F1.scale_x = 1.0
-        split_CD9F1.scale_y = 1.0
-        split_CD9F1.alignment = 'Expand'.upper()
-        if not True: split_CD9F1.operator_context = "EXEC_DEFAULT"
         split_CD9F1.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Convert_To_Rough_Mesh_GN'], 'show_viewport', text='Convert To Rough Mesh', icon_value=0, emboss=True, toggle=True)
         row_9D884 = split_CD9F1.row(heading='', align=True)
-        row_9D884.alert = False
-        row_9D884.enabled = True
-        row_9D884.active = True
-        row_9D884.use_property_split = False
-        row_9D884.use_property_decorate = False
-        row_9D884.scale_x = 1.0
-        row_9D884.scale_y = 1.0
         row_9D884.alignment = 'Right'.upper()
-        row_9D884.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_9D884.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Convert_To_Rough_Mesh_GN'], 'show_render', text='', icon_value=0, emboss=True, toggle=True)
         op = row_9D884.operator('sna.dgs_render_apply_modifier_0f5f2', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'check.svg')), emboss=True, depress=False)
         op.sna_target_object = bpy.context.view_layer.objects.active.name
@@ -48,15 +22,6 @@ def sna_convert_to_rough_mesh_BF549(layout_function, ):
         op.sna_target_object = bpy.context.view_layer.objects.active.name
         op.sna_target_modifier = 'KIRI_3DGS_Convert_To_Rough_Mesh_GN'
         col_D3A3B = box_F10CF.column(heading='', align=False)
-        col_D3A3B.alert = False
-        col_D3A3B.enabled = True
-        col_D3A3B.active = True
-        col_D3A3B.use_property_split = False
-        col_D3A3B.use_property_decorate = False
-        col_D3A3B.scale_x = 1.0
-        col_D3A3B.scale_y = 1.0
-        col_D3A3B.alignment = 'Expand'.upper()
-        col_D3A3B.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_8B7BC = '["' + str('Socket_3' + '"]') 
         col_D3A3B.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Convert_To_Rough_Mesh_GN'], attr_8B7BC), text='Voxel Amount', icon_value=0, emboss=True, toggle=True)
         attr_A4FBE = '["' + str('Socket_4' + '"]') 
@@ -71,40 +36,14 @@ def sna_convert_to_rough_mesh_BF549(layout_function, ):
         col_D3A3B.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Convert_To_Rough_Mesh_GN'], attr_6E61B), text='Filter Islands', icon_value=0, emboss=True, toggle=False)
         if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Convert_To_Rough_Mesh_GN']['Socket_11']:
             col_B8A6E = col_D3A3B.column(heading='', align=False)
-            col_B8A6E.alert = False
-            col_B8A6E.enabled = True
-            col_B8A6E.active = True
-            col_B8A6E.use_property_split = False
-            col_B8A6E.use_property_decorate = False
-            col_B8A6E.scale_x = 1.0
-            col_B8A6E.scale_y = 1.0
-            col_B8A6E.alignment = 'Expand'.upper()
-            col_B8A6E.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_65366 = '["' + str('Socket_12' + '"]') 
             col_B8A6E.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Convert_To_Rough_Mesh_GN'], attr_65366), text='', icon_value=0, emboss=True, toggle=False)
             attr_0DE62 = '["' + str('Socket_10' + '"]') 
             col_B8A6E.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Convert_To_Rough_Mesh_GN'], attr_0DE62), text='Island Threshold', icon_value=0, emboss=True, toggle=False)
     else:
         box_8332A = layout_function.box()
-        box_8332A.alert = False
         box_8332A.enabled = 'OBJECT'==bpy.context.mode
-        box_8332A.active = True
-        box_8332A.use_property_split = False
-        box_8332A.use_property_decorate = False
-        box_8332A.alignment = 'Expand'.upper()
-        box_8332A.scale_x = 1.0
-        box_8332A.scale_y = 1.0
-        if not True: box_8332A.operator_context = "EXEC_DEFAULT"
         row_A4E6D = box_8332A.row(heading='', align=False)
-        row_A4E6D.alert = False
-        row_A4E6D.enabled = True
-        row_A4E6D.active = True
-        row_A4E6D.use_property_split = False
-        row_A4E6D.use_property_decorate = False
-        row_A4E6D.scale_x = 1.0
-        row_A4E6D.scale_y = 1.0
-        row_A4E6D.alignment = 'Expand'.upper()
-        row_A4E6D.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_A4E6D.label(text='Convert To Rough Mesh', icon_value=0)
         op = row_A4E6D.operator('sna.dgs_render_append_rough_mesh_modifier_65da3', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'plus-circle.svg')), emboss=True, depress=False)
         op.sna_create_duplicate = True

--- a/src/convert_vert_3dgs_to_face_3dgs.py
+++ b/src/convert_vert_3dgs_to_face_3dgs.py
@@ -18,9 +18,9 @@ class SNA_OT_Dgs_Render_Convert_Vert_3Dgs_To_Face_3Dgs_E6635(bpy.types.Operator)
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         target_obj_name = bpy.context.view_layer.objects.active.name

--- a/src/create_proxy_from_mesh.py
+++ b/src/create_proxy_from_mesh.py
@@ -19,9 +19,9 @@ class SNA_OT_Dgs_Render_Create_Proxy_From_Mesh_Eafbb(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         exec('import os')

--- a/src/crop_box.py
+++ b/src/crop_box.py
@@ -10,36 +10,10 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_crop_box_F2C60(layout_function, ):
     if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Crop_Box_GN' in bpy.context.view_layer.objects.active.modifiers):
         box_F47C3 = layout_function.box()
-        box_F47C3.alert = False
-        box_F47C3.enabled = True
-        box_F47C3.active = True
-        box_F47C3.use_property_split = False
-        box_F47C3.use_property_decorate = False
-        box_F47C3.alignment = 'Expand'.upper()
-        box_F47C3.scale_x = 1.0
-        box_F47C3.scale_y = 1.0
-        if not True: box_F47C3.operator_context = "EXEC_DEFAULT"
         split_35FA4 = box_F47C3.split(factor=0.5, align=False)
-        split_35FA4.alert = False
-        split_35FA4.enabled = True
-        split_35FA4.active = True
-        split_35FA4.use_property_split = False
-        split_35FA4.use_property_decorate = False
-        split_35FA4.scale_x = 1.0
-        split_35FA4.scale_y = 1.0
-        split_35FA4.alignment = 'Expand'.upper()
-        if not True: split_35FA4.operator_context = "EXEC_DEFAULT"
         split_35FA4.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Crop_Box_GN'], 'show_viewport', text='Crop Box', icon_value=0, emboss=True, toggle=True)
         row_D8B0A = split_35FA4.row(heading='', align=True)
-        row_D8B0A.alert = False
-        row_D8B0A.enabled = True
-        row_D8B0A.active = True
-        row_D8B0A.use_property_split = False
-        row_D8B0A.use_property_decorate = False
-        row_D8B0A.scale_x = 1.0
-        row_D8B0A.scale_y = 1.0
         row_D8B0A.alignment = 'Right'.upper()
-        row_D8B0A.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_D8B0A.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Crop_Box_GN'], 'show_render', text='', icon_value=0, emboss=True, toggle=True)
         op = row_D8B0A.operator('sna.dgs_render_apply_modifier_0f5f2', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'check.svg')), emboss=True, depress=False)
         op.sna_target_object = bpy.context.view_layer.objects.active.name
@@ -48,15 +22,6 @@ def sna_crop_box_F2C60(layout_function, ):
         op.sna_target_object = bpy.context.view_layer.objects.active.name
         op.sna_target_modifier = 'KIRI_3DGS_Crop_Box_GN'
         box_D7E3D = box_F47C3.box()
-        box_D7E3D.alert = False
-        box_D7E3D.enabled = True
-        box_D7E3D.active = True
-        box_D7E3D.use_property_split = False
-        box_D7E3D.use_property_decorate = False
-        box_D7E3D.alignment = 'Expand'.upper()
-        box_D7E3D.scale_x = 1.0
-        box_D7E3D.scale_y = 1.0
-        if not True: box_D7E3D.operator_context = "EXEC_DEFAULT"
         op = box_D7E3D.operator('sna.dgs_render_auto_generate_crop_object_f20d5', text='Auto generate crop object', icon_value=0, emboss=True, depress=False)
         op.sna_filter_mode = 'quick'
         op.sna_filter_epsilon = 0.029999999329447746
@@ -64,15 +29,6 @@ def sna_crop_box_F2C60(layout_function, ):
         op.sna_fast_mode = False
         op.sna_create_convex_hull_object = False
         col_3D26B = box_F47C3.column(heading='', align=True)
-        col_3D26B.alert = False
-        col_3D26B.enabled = True
-        col_3D26B.active = True
-        col_3D26B.use_property_split = False
-        col_3D26B.use_property_decorate = False
-        col_3D26B.scale_x = 1.0
-        col_3D26B.scale_y = 1.0
-        col_3D26B.alignment = 'Expand'.upper()
-        col_3D26B.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_75E1E = '["' + str('Socket_19' + '"]') 
         col_3D26B.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Crop_Box_GN'], attr_75E1E), text='', icon_value=0, emboss=True)
         if (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Crop_Box_GN']['Socket_19'] == 0):
@@ -87,25 +43,8 @@ def sna_crop_box_F2C60(layout_function, ):
             col_3D26B.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Crop_Box_GN'], attr_3021D), text='', icon_value=0, emboss=True)
     else:
         box_08D76 = layout_function.box()
-        box_08D76.alert = False
         box_08D76.enabled = 'OBJECT'==bpy.context.mode
-        box_08D76.active = True
-        box_08D76.use_property_split = False
-        box_08D76.use_property_decorate = False
-        box_08D76.alignment = 'Expand'.upper()
-        box_08D76.scale_x = 1.0
-        box_08D76.scale_y = 1.0
-        if not True: box_08D76.operator_context = "EXEC_DEFAULT"
         row_729E9 = box_08D76.row(heading='', align=False)
-        row_729E9.alert = False
-        row_729E9.enabled = True
-        row_729E9.active = True
-        row_729E9.use_property_split = False
-        row_729E9.use_property_decorate = False
-        row_729E9.scale_x = 1.0
-        row_729E9.scale_y = 1.0
-        row_729E9.alignment = 'Expand'.upper()
-        row_729E9.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_729E9.label(text='Crop Box', icon_value=0)
         op = row_729E9.operator('sna.dgs_render_append_geometry_node_modifier_c2492', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'plus-circle.svg')), emboss=True, depress=False)
         op.sna_node_group_name = 'KIRI_3DGS_Crop_Box_GN'

--- a/src/decimate.py
+++ b/src/decimate.py
@@ -10,36 +10,10 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_decimate_D742E(layout_function, ):
     if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Decimate_GN' in bpy.context.view_layer.objects.active.modifiers):
         box_D6E89 = layout_function.box()
-        box_D6E89.alert = False
-        box_D6E89.enabled = True
-        box_D6E89.active = True
-        box_D6E89.use_property_split = False
-        box_D6E89.use_property_decorate = False
-        box_D6E89.alignment = 'Expand'.upper()
-        box_D6E89.scale_x = 1.0
-        box_D6E89.scale_y = 1.0
-        if not True: box_D6E89.operator_context = "EXEC_DEFAULT"
         split_32B05 = box_D6E89.split(factor=0.5, align=False)
-        split_32B05.alert = False
-        split_32B05.enabled = True
-        split_32B05.active = True
-        split_32B05.use_property_split = False
-        split_32B05.use_property_decorate = False
-        split_32B05.scale_x = 1.0
-        split_32B05.scale_y = 1.0
-        split_32B05.alignment = 'Expand'.upper()
-        if not True: split_32B05.operator_context = "EXEC_DEFAULT"
         split_32B05.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Decimate_GN'], 'show_viewport', text='Decimate', icon_value=0, emboss=True, toggle=True)
         row_3CA54 = split_32B05.row(heading='', align=True)
-        row_3CA54.alert = False
-        row_3CA54.enabled = True
-        row_3CA54.active = True
-        row_3CA54.use_property_split = False
-        row_3CA54.use_property_decorate = False
-        row_3CA54.scale_x = 1.0
-        row_3CA54.scale_y = 1.0
         row_3CA54.alignment = 'Right'.upper()
-        row_3CA54.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_3CA54.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Decimate_GN'], 'show_render', text='', icon_value=0, emboss=True, toggle=True)
         op = row_3CA54.operator('sna.dgs_render_apply_modifier_0f5f2', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'check.svg')), emboss=True, depress=False)
         op.sna_target_object = bpy.context.view_layer.objects.active.name
@@ -48,42 +22,15 @@ def sna_decimate_D742E(layout_function, ):
         op.sna_target_object = bpy.context.view_layer.objects.active.name
         op.sna_target_modifier = 'KIRI_3DGS_Decimate_GN'
         col_49D7B = box_D6E89.column(heading='', align=True)
-        col_49D7B.alert = False
-        col_49D7B.enabled = True
-        col_49D7B.active = True
-        col_49D7B.use_property_split = False
-        col_49D7B.use_property_decorate = False
-        col_49D7B.scale_x = 1.0
-        col_49D7B.scale_y = 1.0
-        col_49D7B.alignment = 'Expand'.upper()
-        col_49D7B.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_C43B9 = '["' + str('Socket_15' + '"]') 
         col_49D7B.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Decimate_GN'], attr_C43B9), text='Decimate Percentage', icon_value=0, emboss=True)
         attr_97660 = '["' + str('Socket_16' + '"]') 
         col_49D7B.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Decimate_GN'], attr_97660), text='Decimate Seed', icon_value=0, emboss=True)
         col_CB092 = box_D6E89.column(heading='', align=False)
-        col_CB092.alert = False
-        col_CB092.enabled = True
-        col_CB092.active = True
-        col_CB092.use_property_split = False
-        col_CB092.use_property_decorate = False
-        col_CB092.scale_x = 1.0
-        col_CB092.scale_y = 1.0
-        col_CB092.alignment = 'Expand'.upper()
-        col_CB092.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_93B93 = '["' + str('Socket_18' + '"]') 
         col_CB092.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Decimate_GN'], attr_93B93), text='Decimate Masking', icon_value=0, emboss=True, toggle=True)
         if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Decimate_GN']['Socket_18']:
             col_70B17 = col_CB092.column(heading='', align=False)
-            col_70B17.alert = False
-            col_70B17.enabled = True
-            col_70B17.active = True
-            col_70B17.use_property_split = False
-            col_70B17.use_property_decorate = False
-            col_70B17.scale_x = 1.0
-            col_70B17.scale_y = 1.0
-            col_70B17.alignment = 'Expand'.upper()
-            col_70B17.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_B0634 = '["' + str('Socket_20' + '"]') 
             col_70B17.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Decimate_GN'], attr_B0634), text='', icon_value=0, emboss=True, toggle=True)
             attr_BD569 = '["' + str('Socket_21' + '"]') 
@@ -93,25 +40,8 @@ def sna_decimate_D742E(layout_function, ):
                 col_70B17.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Decimate_GN'], attr_2288A), text='Distance Threshold', icon_value=0, emboss=True, toggle=True)
     else:
         box_2EA63 = layout_function.box()
-        box_2EA63.alert = False
         box_2EA63.enabled = 'OBJECT'==bpy.context.mode
-        box_2EA63.active = True
-        box_2EA63.use_property_split = False
-        box_2EA63.use_property_decorate = False
-        box_2EA63.alignment = 'Expand'.upper()
-        box_2EA63.scale_x = 1.0
-        box_2EA63.scale_y = 1.0
-        if not True: box_2EA63.operator_context = "EXEC_DEFAULT"
         row_DE93F = box_2EA63.row(heading='', align=False)
-        row_DE93F.alert = False
-        row_DE93F.enabled = True
-        row_DE93F.active = True
-        row_DE93F.use_property_split = False
-        row_DE93F.use_property_decorate = False
-        row_DE93F.scale_x = 1.0
-        row_DE93F.scale_y = 1.0
-        row_DE93F.alignment = 'Expand'.upper()
-        row_DE93F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_DE93F.label(text='Decimate', icon_value=0)
         op = row_DE93F.operator('sna.dgs_render_append_geometry_node_modifier_c2492', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'plus-circle.svg')), emboss=True, depress=False)
         op.sna_node_group_name = 'KIRI_3DGS_Decimate_GN'

--- a/src/dgs_mods_uv_edit.py
+++ b/src/dgs_mods_uv_edit.py
@@ -10,36 +10,10 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_dgs_mods_uv_edit_7D8A8(layout_function, ):
     if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Render_UV_Edit_GN' in bpy.context.view_layer.objects.active.modifiers):
         box_9FF77 = layout_function.box()
-        box_9FF77.alert = False
-        box_9FF77.enabled = True
-        box_9FF77.active = True
-        box_9FF77.use_property_split = False
-        box_9FF77.use_property_decorate = False
-        box_9FF77.alignment = 'Expand'.upper()
-        box_9FF77.scale_x = 1.0
-        box_9FF77.scale_y = 1.0
-        if not True: box_9FF77.operator_context = "EXEC_DEFAULT"
         split_CE162 = box_9FF77.split(factor=0.5, align=False)
-        split_CE162.alert = False
-        split_CE162.enabled = True
-        split_CE162.active = True
-        split_CE162.use_property_split = False
-        split_CE162.use_property_decorate = False
-        split_CE162.scale_x = 1.0
-        split_CE162.scale_y = 1.0
-        split_CE162.alignment = 'Expand'.upper()
-        if not True: split_CE162.operator_context = "EXEC_DEFAULT"
         split_CE162.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], 'show_viewport', text='UV Edit', icon_value=0, emboss=True, toggle=True)
         row_DE4FE = split_CE162.row(heading='', align=True)
-        row_DE4FE.alert = False
-        row_DE4FE.enabled = True
-        row_DE4FE.active = True
-        row_DE4FE.use_property_split = False
-        row_DE4FE.use_property_decorate = False
-        row_DE4FE.scale_x = 1.0
-        row_DE4FE.scale_y = 1.0
         row_DE4FE.alignment = 'Right'.upper()
-        row_DE4FE.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_DE4FE.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], 'show_render', text='', icon_value=0, emboss=True, toggle=True)
         op = row_DE4FE.operator('sna.dgs_render_apply_modifier_0f5f2', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'check.svg')), emboss=True, depress=False)
         op.sna_target_object = bpy.context.view_layer.objects.active.name
@@ -48,30 +22,12 @@ def sna_dgs_mods_uv_edit_7D8A8(layout_function, ):
         op.sna_target_object = bpy.context.view_layer.objects.active.name
         op.sna_target_modifier = 'KIRI_3DGS_Render_UV_Edit_GN'
         box_E2654 = box_9FF77.box()
-        box_E2654.alert = False
-        box_E2654.enabled = True
-        box_E2654.active = True
-        box_E2654.use_property_split = False
-        box_E2654.use_property_decorate = False
-        box_E2654.alignment = 'Expand'.upper()
-        box_E2654.scale_x = 1.0
-        box_E2654.scale_y = 1.0
-        if not True: box_E2654.operator_context = "EXEC_DEFAULT"
         attr_B95E2 = '["' + str('Socket_101' + '"]') 
         box_E2654.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_B95E2), text='UV Name', icon_value=0, emboss=True, toggle=True)
         attr_5057A = '["' + str('Socket_81' + '"]') 
         box_E2654.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_5057A), text='', icon_value=0, emboss=True, toggle=True)
         if (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN']['Socket_81'] == 1):
             col_B844C = box_E2654.column(heading='', align=True)
-            col_B844C.alert = False
-            col_B844C.enabled = True
-            col_B844C.active = True
-            col_B844C.use_property_split = False
-            col_B844C.use_property_decorate = False
-            col_B844C.scale_x = 1.0
-            col_B844C.scale_y = 1.0
-            col_B844C.alignment = 'Expand'.upper()
-            col_B844C.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_09238 = '["' + str('Socket_79' + '"]') 
             col_B844C.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_09238), text='', icon_value=0, emboss=True, toggle=True)
             if (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN']['Socket_79'] == 1):
@@ -80,39 +36,12 @@ def sna_dgs_mods_uv_edit_7D8A8(layout_function, ):
             attr_BB6E4 = '["' + str('Socket_105' + '"]') 
             col_B844C.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_BB6E4), text='', icon_value=0, emboss=True, toggle=True)
         box_06FCC = box_9FF77.box()
-        box_06FCC.alert = False
-        box_06FCC.enabled = True
-        box_06FCC.active = True
-        box_06FCC.use_property_split = False
-        box_06FCC.use_property_decorate = False
-        box_06FCC.alignment = 'Expand'.upper()
-        box_06FCC.scale_x = 1.0
-        box_06FCC.scale_y = 1.0
-        if not True: box_06FCC.operator_context = "EXEC_DEFAULT"
         attr_86FBB = '["' + str('Socket_83' + '"]') 
         box_06FCC.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_86FBB), text='Align to direction', icon_value=0, emboss=True)
         if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN']['Socket_83']:
             col_9BFFE = box_06FCC.column(heading='', align=True)
-            col_9BFFE.alert = False
-            col_9BFFE.enabled = True
-            col_9BFFE.active = True
-            col_9BFFE.use_property_split = False
-            col_9BFFE.use_property_decorate = False
-            col_9BFFE.scale_x = 1.0
-            col_9BFFE.scale_y = 1.0
-            col_9BFFE.alignment = 'Expand'.upper()
-            col_9BFFE.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             col_9BFFE.label(text='Axis', icon_value=0)
             row_A1034 = col_9BFFE.row(heading='', align=False)
-            row_A1034.alert = False
-            row_A1034.enabled = True
-            row_A1034.active = True
-            row_A1034.use_property_split = False
-            row_A1034.use_property_decorate = False
-            row_A1034.scale_x = 1.0
-            row_A1034.scale_y = 1.0
-            row_A1034.alignment = 'Expand'.upper()
-            row_A1034.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_9CCDE = '["' + str('Socket_85' + '"]') 
             row_A1034.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_9CCDE), text='.', icon_value=0, emboss=True, expand=True)
             attr_1E2BC = '["' + str('Socket_84' + '"]') 
@@ -120,28 +49,10 @@ def sna_dgs_mods_uv_edit_7D8A8(layout_function, ):
             attr_81350 = '["' + str('Socket_86' + '"]') 
             col_9BFFE.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_81350), text='Rotation', icon_value=0, emboss=True, toggle=True)
         box_3BC41 = box_9FF77.box()
-        box_3BC41.alert = False
-        box_3BC41.enabled = True
-        box_3BC41.active = True
-        box_3BC41.use_property_split = False
-        box_3BC41.use_property_decorate = False
-        box_3BC41.alignment = 'Expand'.upper()
-        box_3BC41.scale_x = 1.0
-        box_3BC41.scale_y = 1.0
-        if not True: box_3BC41.operator_context = "EXEC_DEFAULT"
         attr_6A5D2 = '["' + str('Socket_106' + '"]') 
         box_3BC41.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_6A5D2), text='Transform', icon_value=0, emboss=True)
         if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN']['Socket_106']:
             col_A8AB9 = box_3BC41.column(heading='', align=False)
-            col_A8AB9.alert = False
-            col_A8AB9.enabled = True
-            col_A8AB9.active = True
-            col_A8AB9.use_property_split = False
-            col_A8AB9.use_property_decorate = False
-            col_A8AB9.scale_x = 1.0
-            col_A8AB9.scale_y = 1.0
-            col_A8AB9.alignment = 'Expand'.upper()
-            col_A8AB9.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_082AE = '["' + str('Socket_87' + '"]') 
             col_A8AB9.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_082AE), text='Translation', icon_value=0, emboss=True, expand=True)
             attr_1AE94 = '["' + str('Socket_88' + '"]') 
@@ -149,15 +60,6 @@ def sna_dgs_mods_uv_edit_7D8A8(layout_function, ):
             attr_0F93F = '["' + str('Socket_89' + '"]') 
             col_A8AB9.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_0F93F), text='Scale', icon_value=0, emboss=True, toggle=True)
             row_77081 = col_A8AB9.row(heading='', align=False)
-            row_77081.alert = False
-            row_77081.enabled = True
-            row_77081.active = True
-            row_77081.use_property_split = False
-            row_77081.use_property_decorate = False
-            row_77081.scale_x = 1.0
-            row_77081.scale_y = 1.0
-            row_77081.alignment = 'Expand'.upper()
-            row_77081.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_20D92 = '["' + str('Socket_91' + '"]') 
             row_77081.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_20D92), text='Flip U', icon_value=0, emboss=True, toggle=True)
             attr_55098 = '["' + str('Socket_92' + '"]') 
@@ -166,15 +68,6 @@ def sna_dgs_mods_uv_edit_7D8A8(layout_function, ):
             col_A8AB9.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_65309), text='Randomize', icon_value=0, emboss=True, toggle=False)
             if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN']['Socket_95']:
                 col_06A74 = col_A8AB9.column(heading='', align=False)
-                col_06A74.alert = False
-                col_06A74.enabled = True
-                col_06A74.active = True
-                col_06A74.use_property_split = False
-                col_06A74.use_property_decorate = False
-                col_06A74.scale_x = 1.0
-                col_06A74.scale_y = 1.0
-                col_06A74.alignment = 'Expand'.upper()
-                col_06A74.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 attr_38294 = '["' + str('Socket_96' + '"]') 
                 col_06A74.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_38294), text='Offset', icon_value=0, emboss=True, toggle=True)
                 attr_850DC = '["' + str('Socket_97' + '"]') 
@@ -183,24 +76,7 @@ def sna_dgs_mods_uv_edit_7D8A8(layout_function, ):
                 col_06A74.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Render_UV_Edit_GN'], attr_CF180), text='Seed', icon_value=0, emboss=True, toggle=True)
     else:
         box_01F2C = layout_function.box()
-        box_01F2C.alert = False
         box_01F2C.enabled = 'OBJECT'==bpy.context.mode
-        box_01F2C.active = True
-        box_01F2C.use_property_split = False
-        box_01F2C.use_property_decorate = False
-        box_01F2C.alignment = 'Expand'.upper()
-        box_01F2C.scale_x = 1.0
-        box_01F2C.scale_y = 1.0
-        if not True: box_01F2C.operator_context = "EXEC_DEFAULT"
         row_34CC5 = box_01F2C.row(heading='', align=False)
-        row_34CC5.alert = False
-        row_34CC5.enabled = True
-        row_34CC5.active = True
-        row_34CC5.use_property_split = False
-        row_34CC5.use_property_decorate = False
-        row_34CC5.scale_x = 1.0
-        row_34CC5.scale_y = 1.0
-        row_34CC5.alignment = 'Expand'.upper()
-        row_34CC5.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_34CC5.label(text='UV Edit', icon_value=0)
         op = row_34CC5.operator('sna.dgs_render_add_uv_edit_modifier_e8ae6', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'plus-circle.svg')), emboss=True, depress=False)

--- a/src/dgs_render_main_function_menu.py
+++ b/src/dgs_render_main_function_menu.py
@@ -13,15 +13,6 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_dgs_render__main_function_menu_019C7(layout_function, ):
     box_BDC6F = layout_function.box()
-    box_BDC6F.alert = False
-    box_BDC6F.enabled = True
-    box_BDC6F.active = True
-    box_BDC6F.use_property_split = False
-    box_BDC6F.use_property_decorate = False
-    box_BDC6F.alignment = 'Expand'.upper()
-    box_BDC6F.scale_x = 1.0
-    box_BDC6F.scale_y = 1.0
-    if not True: box_BDC6F.operator_context = "EXEC_DEFAULT"
     if (bpy.context.view_layer.objects.active == None):
         pass
     else:
@@ -29,26 +20,9 @@ def sna_dgs_render__main_function_menu_019C7(layout_function, ):
             layout_function = box_BDC6F
             sna_active_3dgs_mesh_object_menu_9588F(layout_function, )
     box_DCCA2 = box_BDC6F.box()
-    box_DCCA2.alert = False
     box_DCCA2.enabled = ((not ((bpy.context.scene.sna_dgs_scene_properties.r2_update_type == 'Interval Update') and (not bpy.context.scene.sna_dgs_scene_properties.r2_interval_stop))) and 'OBJECT'==bpy.context.mode)
-    box_DCCA2.active = True
-    box_DCCA2.use_property_split = False
-    box_DCCA2.use_property_decorate = False
-    box_DCCA2.alignment = 'Expand'.upper()
-    box_DCCA2.scale_x = 1.0
-    box_DCCA2.scale_y = 1.0
-    if not True: box_DCCA2.operator_context = "EXEC_DEFAULT"
     box_DCCA2.label(text='Active Mode', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
     row_A59C6 = box_DCCA2.row(heading='', align=False)
-    row_A59C6.alert = False
-    row_A59C6.enabled = True
-    row_A59C6.active = True
-    row_A59C6.use_property_split = False
-    row_A59C6.use_property_decorate = False
-    row_A59C6.scale_x = 1.0
-    row_A59C6.scale_y = 1.0
-    row_A59C6.alignment = 'Expand'.upper()
-    row_A59C6.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     row_A59C6.prop(bpy.context.scene.sna_dgs_scene_properties, 'active_mode', text=bpy.context.scene.sna_dgs_scene_properties.active_mode, icon_value=0, emboss=True, expand=True)
     if str(bpy.context.scene.sna_dgs_scene_properties.active_mode) == "Edit":
         layout_function = box_BDC6F

--- a/src/disable_hq_overlap.py
+++ b/src/disable_hq_overlap.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Disable_Hq_Overlap_34678(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         bpy.data.objects.remove(object=bpy.data.objects['KIRI_HQ_Merged_Object'], do_unlink=True, do_id_user=True, do_ui_user=True, )
@@ -35,15 +35,6 @@ class SNA_OT_Dgs_Render_Disable_Hq_Overlap_34678(bpy.types.Operator):
     def draw(self, context):
         layout = self.layout
         box_2D485 = layout.box()
-        box_2D485.alert = False
-        box_2D485.enabled = True
-        box_2D485.active = True
-        box_2D485.use_property_split = False
-        box_2D485.use_property_decorate = False
-        box_2D485.alignment = 'Expand'.upper()
-        box_2D485.scale_x = 1.0
-        box_2D485.scale_y = 1.0
-        if not True: box_2D485.operator_context = "EXEC_DEFAULT"
         box_2D485.label(text='HQ Object Found In Scene', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_2D485.label(text='        Remove It?', icon_value=0)
 

--- a/src/edit_menu.py
+++ b/src/edit_menu.py
@@ -22,231 +22,70 @@ def sna_edit_menu_D3299(layout_function, ):
         sna_edit_select_tools_D0175(layout_function, )
     else:
         col_05CDB = layout_function.column(heading='', align=False)
-        col_05CDB.alert = False
-        col_05CDB.enabled = True
-        col_05CDB.active = True
-        col_05CDB.use_property_split = False
-        col_05CDB.use_property_decorate = False
-        col_05CDB.scale_x = 1.0
-        col_05CDB.scale_y = 1.0
-        col_05CDB.alignment = 'Expand'.upper()
-        col_05CDB.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         if (bpy.context.scene.sna_dgs_scene_properties.active_mode == 'Edit'):
             box_09ED1 = col_05CDB.box()
-            box_09ED1.alert = False
-            box_09ED1.enabled = True
-            box_09ED1.active = True
-            box_09ED1.use_property_split = False
-            box_09ED1.use_property_decorate = False
-            box_09ED1.alignment = 'Expand'.upper()
-            box_09ED1.scale_x = 1.0
-            box_09ED1.scale_y = 1.0
-            if not True: box_09ED1.operator_context = "EXEC_DEFAULT"
             grid_B53F5 = box_09ED1.grid_flow(columns=2, row_major=True, even_columns=False, even_rows=False, align=True)
-            grid_B53F5.enabled = True
-            grid_B53F5.active = True
-            grid_B53F5.use_property_split = False
-            grid_B53F5.use_property_decorate = False
-            grid_B53F5.alignment = 'Expand'.upper()
-            grid_B53F5.scale_x = 1.0
-            grid_B53F5.scale_y = 1.0
-            if not True: grid_B53F5.operator_context = "EXEC_DEFAULT"
             grid_B53F5.prop(bpy.context.scene.sna_dgs_scene_properties, 'edit_mode_menu', text=bpy.context.scene.sna_dgs_scene_properties.edit_mode_menu, icon_value=0, emboss=True, expand=True)
         if bpy.context.scene.sna_dgs_scene_properties.edit_mode_menu == "Import":
             box_456A0 = col_05CDB.box()
-            box_456A0.alert = False
-            box_456A0.enabled = True
-            box_456A0.active = True
-            box_456A0.use_property_split = False
-            box_456A0.use_property_decorate = False
-            box_456A0.alignment = 'Expand'.upper()
-            box_456A0.scale_x = 1.0
-            box_456A0.scale_y = 1.0
-            if not True: box_456A0.operator_context = "EXEC_DEFAULT"
             layout_function = box_456A0
             sna_import_menu_94FB1(layout_function, )
         elif bpy.context.scene.sna_dgs_scene_properties.edit_mode_menu == "Modifiers":
             if (bpy.context.view_layer.objects.active == None):
                 box_BCC27 = col_05CDB.box()
-                box_BCC27.alert = False
-                box_BCC27.enabled = True
-                box_BCC27.active = True
-                box_BCC27.use_property_split = False
-                box_BCC27.use_property_decorate = False
-                box_BCC27.alignment = 'Expand'.upper()
-                box_BCC27.scale_x = 1.0
-                box_BCC27.scale_y = 1.0
-                if not True: box_BCC27.operator_context = "EXEC_DEFAULT"
                 box_BCC27.label(text='No Active Object', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
             else:
                 box_15E02 = col_05CDB.box()
-                box_15E02.alert = False
-                box_15E02.enabled = True
-                box_15E02.active = True
-                box_15E02.use_property_split = False
-                box_15E02.use_property_decorate = False
-                box_15E02.alignment = 'Expand'.upper()
-                box_15E02.scale_x = 1.0
-                box_15E02.scale_y = 1.0
-                if not True: box_15E02.operator_context = "EXEC_DEFAULT"
                 layout_function = box_15E02
                 sna_modify_menu_AEA26(layout_function, )
         elif bpy.context.scene.sna_dgs_scene_properties.edit_mode_menu == "Colour":
             if (bpy.context.view_layer.objects.active == None):
                 box_7DC02 = col_05CDB.box()
-                box_7DC02.alert = False
-                box_7DC02.enabled = True
-                box_7DC02.active = True
-                box_7DC02.use_property_split = False
-                box_7DC02.use_property_decorate = False
-                box_7DC02.alignment = 'Expand'.upper()
-                box_7DC02.scale_x = 1.0
-                box_7DC02.scale_y = 1.0
-                if not True: box_7DC02.operator_context = "EXEC_DEFAULT"
                 box_7DC02.label(text='No Active Object', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
             else:
                 if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Adjust_Colour_And_Material' in bpy.context.view_layer.objects.active.modifiers):
                     box_FB8A4 = col_05CDB.box()
-                    box_FB8A4.alert = False
-                    box_FB8A4.enabled = True
-                    box_FB8A4.active = True
-                    box_FB8A4.use_property_split = False
-                    box_FB8A4.use_property_decorate = False
-                    box_FB8A4.alignment = 'Expand'.upper()
-                    box_FB8A4.scale_x = 1.0
-                    box_FB8A4.scale_y = 1.0
-                    if not True: box_FB8A4.operator_context = "EXEC_DEFAULT"
                     layout_function = box_FB8A4
                     sna_colour_function_interface_3A6A5(layout_function, )
                 else:
                     box_6F020 = col_05CDB.box()
-                    box_6F020.alert = False
-                    box_6F020.enabled = True
-                    box_6F020.active = True
-                    box_6F020.use_property_split = False
-                    box_6F020.use_property_decorate = False
-                    box_6F020.alignment = 'Expand'.upper()
-                    box_6F020.scale_x = 1.0
-                    box_6F020.scale_y = 1.0
-                    if not True: box_6F020.operator_context = "EXEC_DEFAULT"
                     box_6F020.label(text='Active Object is missing the ', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
                     box_6F020.label(text='Adjust_Colour_And_Material modifier', icon_value=0)
         elif bpy.context.scene.sna_dgs_scene_properties.edit_mode_menu == "Animate":
             if (bpy.context.view_layer.objects.active == None):
                 box_36685 = col_05CDB.box()
-                box_36685.alert = False
-                box_36685.enabled = True
-                box_36685.active = True
-                box_36685.use_property_split = False
-                box_36685.use_property_decorate = False
-                box_36685.alignment = 'Expand'.upper()
-                box_36685.scale_x = 1.0
-                box_36685.scale_y = 1.0
-                if not True: box_36685.operator_context = "EXEC_DEFAULT"
                 box_36685.label(text='No Active Object', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
             else:
                 box_2B760 = col_05CDB.box()
-                box_2B760.alert = False
-                box_2B760.enabled = True
-                box_2B760.active = True
-                box_2B760.use_property_split = False
-                box_2B760.use_property_decorate = False
-                box_2B760.alignment = 'Expand'.upper()
-                box_2B760.scale_x = 1.0
-                box_2B760.scale_y = 1.0
-                if not True: box_2B760.operator_context = "EXEC_DEFAULT"
                 layout_function = box_2B760
                 sna_animate_function_interface_57F9E(layout_function, )
         elif bpy.context.scene.sna_dgs_scene_properties.edit_mode_menu == "HQ / LQ":
             box_50BC2 = col_05CDB.box()
-            box_50BC2.alert = False
-            box_50BC2.enabled = True
-            box_50BC2.active = True
-            box_50BC2.use_property_split = False
-            box_50BC2.use_property_decorate = False
-            box_50BC2.alignment = 'Expand'.upper()
-            box_50BC2.scale_x = 1.0
-            box_50BC2.scale_y = 1.0
-            if not True: box_50BC2.operator_context = "EXEC_DEFAULT"
             layout_function = box_50BC2
             sna_hq_mode_function_interface_17C41(layout_function, )
         elif bpy.context.scene.sna_dgs_scene_properties.edit_mode_menu == "Export":
             if (bpy.context.view_layer.objects.active == None):
                 box_A093C = col_05CDB.box()
-                box_A093C.alert = False
-                box_A093C.enabled = True
-                box_A093C.active = True
-                box_A093C.use_property_split = False
-                box_A093C.use_property_decorate = False
-                box_A093C.alignment = 'Expand'.upper()
-                box_A093C.scale_x = 1.0
-                box_A093C.scale_y = 1.0
-                if not True: box_A093C.operator_context = "EXEC_DEFAULT"
                 box_A093C.label(text='No Active Object', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
             else:
                 if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Write F_DC_And_Merge' in bpy.context.view_layer.objects.active.modifiers):
                     if (len(bpy.context.view_layer.objects.selected) > 1):
                         box_7DD8C = col_05CDB.box()
-                        box_7DD8C.alert = False
-                        box_7DD8C.enabled = True
-                        box_7DD8C.active = True
-                        box_7DD8C.use_property_split = False
-                        box_7DD8C.use_property_decorate = False
-                        box_7DD8C.alignment = 'Expand'.upper()
-                        box_7DD8C.scale_x = 1.0
-                        box_7DD8C.scale_y = 1.0
-                        if not True: box_7DD8C.operator_context = "EXEC_DEFAULT"
                         box_7DD8C.label(text='Only select 1 object for export', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
                     else:
                         box_3E038 = col_05CDB.box()
-                        box_3E038.alert = False
-                        box_3E038.enabled = True
-                        box_3E038.active = True
-                        box_3E038.use_property_split = False
-                        box_3E038.use_property_decorate = False
-                        box_3E038.alignment = 'Expand'.upper()
-                        box_3E038.scale_x = 1.0
-                        box_3E038.scale_y = 1.0
-                        if not True: box_3E038.operator_context = "EXEC_DEFAULT"
                         layout_function = box_3E038
                         sna_export_3dgs_function_interface_CDF59(layout_function, )
                 else:
                     box_DE950 = col_05CDB.box()
-                    box_DE950.alert = False
-                    box_DE950.enabled = True
-                    box_DE950.active = True
-                    box_DE950.use_property_split = False
-                    box_DE950.use_property_decorate = False
-                    box_DE950.alignment = 'Expand'.upper()
-                    box_DE950.scale_x = 1.0
-                    box_DE950.scale_y = 1.0
-                    if not True: box_DE950.operator_context = "EXEC_DEFAULT"
                     box_DE950.label(text='The Active Object is missing the', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
                     box_DE950.label(text='Write F_DC_And_Merge modifier', icon_value=0)
         elif bpy.context.scene.sna_dgs_scene_properties.edit_mode_menu == "Rig":
             box_D5082 = col_05CDB.box()
-            box_D5082.alert = False
-            box_D5082.enabled = True
-            box_D5082.active = True
-            box_D5082.use_property_split = False
-            box_D5082.use_property_decorate = False
-            box_D5082.alignment = 'Expand'.upper()
-            box_D5082.scale_x = 1.0
-            box_D5082.scale_y = 1.0
-            if not True: box_D5082.operator_context = "EXEC_DEFAULT"
             layout_function = box_D5082
             sna_rig_891FC(layout_function, )
         elif bpy.context.scene.sna_dgs_scene_properties.edit_mode_menu == "Light Bake":
             box_6F2D7 = col_05CDB.box()
-            box_6F2D7.alert = False
-            box_6F2D7.enabled = True
-            box_6F2D7.active = True
-            box_6F2D7.use_property_split = False
-            box_6F2D7.use_property_decorate = False
-            box_6F2D7.alignment = 'Expand'.upper()
-            box_6F2D7.scale_x = 1.0
-            box_6F2D7.scale_y = 1.0
-            if not True: box_6F2D7.operator_context = "EXEC_DEFAULT"
             layout_function = box_6F2D7
             sna_light_bake_8F346(layout_function, )
         else:

--- a/src/edit_select_tools.py
+++ b/src/edit_select_tools.py
@@ -10,52 +10,16 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_edit_select_tools_D0175(layout_function, ):
     box_DC33F = layout_function.box()
-    box_DC33F.alert = False
-    box_DC33F.enabled = True
-    box_DC33F.active = True
-    box_DC33F.use_property_split = False
-    box_DC33F.use_property_decorate = False
-    box_DC33F.alignment = 'Expand'.upper()
-    box_DC33F.scale_x = 1.0
-    box_DC33F.scale_y = 1.0
-    if not True: box_DC33F.operator_context = "EXEC_DEFAULT"
     box_DC33F.label(text='Select Tools', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
     box_243AA = box_DC33F.box()
-    box_243AA.alert = False
-    box_243AA.enabled = True
-    box_243AA.active = True
-    box_243AA.use_property_split = False
-    box_243AA.use_property_decorate = False
-    box_243AA.alignment = 'Expand'.upper()
-    box_243AA.scale_x = 1.0
-    box_243AA.scale_y = 1.0
-    if not True: box_243AA.operator_context = "EXEC_DEFAULT"
     box_243AA.label(text='Select by Object', icon_value=0)
     layout_function = box_243AA
     sna_append_wire_primitives_15D73(layout_function, )
     box_243AA.prop(bpy.context.scene.sna_dgs_scene_properties, 'select_select_by_obj', text='', icon_value=0, emboss=True)
     row_187F8 = box_243AA.row(heading='', align=False)
-    row_187F8.alert = False
-    row_187F8.enabled = True
-    row_187F8.active = True
-    row_187F8.use_property_split = False
-    row_187F8.use_property_decorate = False
-    row_187F8.scale_x = 1.0
-    row_187F8.scale_y = 1.0
-    row_187F8.alignment = 'Expand'.upper()
-    row_187F8.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     row_187F8.prop(bpy.context.scene.sna_dgs_scene_properties, 'select_obj_select_mode', text=bpy.context.scene.sna_dgs_scene_properties.select_obj_select_mode, icon_value=0, emboss=True, expand=True)
     op = box_243AA.operator('sna.dgs_render_select_by_object_92f9c', text='Select', icon_value=0, emboss=True, depress=False)
     box_2DF89 = box_DC33F.box()
-    box_2DF89.alert = False
-    box_2DF89.enabled = True
-    box_2DF89.active = True
-    box_2DF89.use_property_split = False
-    box_2DF89.use_property_decorate = False
-    box_2DF89.alignment = 'Expand'.upper()
-    box_2DF89.scale_x = 1.0
-    box_2DF89.scale_y = 1.0
-    if not True: box_2DF89.operator_context = "EXEC_DEFAULT"
     box_2DF89.label(text='Select by attribute', icon_value=0)
     box_2DF89.prop(bpy.context.scene.sna_dgs_scene_properties, 'select_attribute_type', text=bpy.context.scene.sna_dgs_scene_properties.select_attribute_type, icon_value=0, emboss=True, expand=True)
     op = box_2DF89.operator('sna.dgs_render_attribute_select_51c86', text='Select', icon_value=0, emboss=True, depress=False)

--- a/src/end_proxy_rig_updates.py
+++ b/src/end_proxy_rig_updates.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_End_Proxy_Rig_Updates_60C6A(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         bpy.context.scene.sna_dgs_scene_properties.rig_interval_stop = True

--- a/src/export_3dgs_function_interface.py
+++ b/src/export_3dgs_function_interface.py
@@ -10,92 +10,32 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_export_3dgs_function_interface_CDF59(layout_function, ):
     if bpy.context.preferences.addons[__package__].preferences.sna_show_tips:
         box_9553E = layout_function.box()
-        box_9553E.alert = False
-        box_9553E.enabled = True
-        box_9553E.active = True
-        box_9553E.use_property_split = False
-        box_9553E.use_property_decorate = False
-        box_9553E.alignment = 'Expand'.upper()
-        box_9553E.scale_x = 1.0
-        box_9553E.scale_y = 1.0
-        if not True: box_9553E.operator_context = "EXEC_DEFAULT"
         box_9553E.label(text='If you have applied scale or rotation', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_9553E.label(text="using Blender's native Apply Transform,", icon_value=0)
         box_9553E.label(text='3DGS attributes will be corrupted', icon_value=0)
     row_0B94F = layout_function.row(heading='', align=False)
-    row_0B94F.alert = False
-    row_0B94F.enabled = True
-    row_0B94F.active = True
-    row_0B94F.use_property_split = False
-    row_0B94F.use_property_decorate = False
-    row_0B94F.scale_x = 1.0
-    row_0B94F.scale_y = 1.0
-    row_0B94F.alignment = 'Expand'.upper()
-    row_0B94F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     row_0B94F.prop(bpy.context.scene.sna_dgs_scene_properties, 'export_single_or_sequence', text=bpy.context.scene.sna_dgs_scene_properties.export_single_or_sequence, icon_value=0, emboss=True, expand=True)
     col_11CDA = layout_function.column(heading='', align=False)
-    col_11CDA.alert = False
-    col_11CDA.enabled = True
-    col_11CDA.active = True
-    col_11CDA.use_property_split = False
-    col_11CDA.use_property_decorate = False
-    col_11CDA.scale_x = 1.0
-    col_11CDA.scale_y = 1.0
-    col_11CDA.alignment = 'Expand'.upper()
-    col_11CDA.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_11CDA.label(text='Output Directory', icon_value=0)
     col_11CDA.prop(bpy.context.scene.sna_dgs_scene_properties, 'export_output_path', text='', icon_value=0, emboss=True)
     if bpy.context.scene.sna_dgs_scene_properties.export_single_or_sequence == "3DGS":
         layout_function.prop(bpy.context.scene.sna_dgs_scene_properties, 'export_suffix', text='suffix', icon_value=0, emboss=True)
     elif bpy.context.scene.sna_dgs_scene_properties.export_single_or_sequence == "4DGS":
         row_1B925 = layout_function.row(heading='', align=False)
-        row_1B925.alert = False
-        row_1B925.enabled = True
-        row_1B925.active = True
-        row_1B925.use_property_split = False
-        row_1B925.use_property_decorate = False
-        row_1B925.scale_x = 1.0
-        row_1B925.scale_y = 1.0
-        row_1B925.alignment = 'Expand'.upper()
-        row_1B925.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_1B925.label(text='Rig Behaviour', icon_value=0)
         row_1B925.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_render_rig_cache_mode', text='', icon_value=0, emboss=True)
     else:
         pass
     col_AA350 = layout_function.column(heading='', align=False)
-    col_AA350.alert = False
     col_AA350.enabled = ('OBJECT'==bpy.context.mode and (bpy.context.scene.sna_dgs_scene_properties.export_output_path != ''))
-    col_AA350.active = True
-    col_AA350.use_property_split = False
-    col_AA350.use_property_decorate = False
-    col_AA350.scale_x = 1.0
-    col_AA350.scale_y = 1.0
-    col_AA350.alignment = 'Expand'.upper()
-    col_AA350.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     if bpy.context.scene.sna_dgs_scene_properties.export_single_or_sequence == "3DGS":
         col_41DA9 = col_AA350.column(heading='', align=False)
-        col_41DA9.alert = False
-        col_41DA9.enabled = True
-        col_41DA9.active = True
-        col_41DA9.use_property_split = False
-        col_41DA9.use_property_decorate = False
-        col_41DA9.scale_x = 1.0
         col_41DA9.scale_y = 2.0
-        col_41DA9.alignment = 'Expand'.upper()
-        col_41DA9.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         op = col_41DA9.operator('sna.dgs_render_export_mesh_as_3dgs4dgs_ce2f7', text='Export 3DGS', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'export.svg')), emboss=True, depress=False)
         op.sna_send_to_world_centre = False
     elif bpy.context.scene.sna_dgs_scene_properties.export_single_or_sequence == "4DGS":
         col_8AE14 = col_AA350.column(heading='', align=False)
-        col_8AE14.alert = False
-        col_8AE14.enabled = True
-        col_8AE14.active = True
-        col_8AE14.use_property_split = False
-        col_8AE14.use_property_decorate = False
-        col_8AE14.scale_x = 1.0
         col_8AE14.scale_y = 2.0
-        col_8AE14.alignment = 'Expand'.upper()
-        col_8AE14.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         op = col_8AE14.operator('sna.dgs_render_export_mesh_as_3dgs4dgs_ce2f7', text='Export PLY Sequence', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'export.svg')), emboss=True, depress=False)
         op.sna_send_to_world_centre = False
     else:

--- a/src/export_mesh_as_3dgs4dgs.py
+++ b/src/export_mesh_as_3dgs4dgs.py
@@ -19,9 +19,9 @@ class SNA_OT_Dgs_Render_Export_Mesh_As_3Dgs4Dgs_Ce2F7(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         if os.path.isdir(bpy.context.scene.sna_dgs_scene_properties.export_output_path):
@@ -393,42 +393,15 @@ class SNA_OT_Dgs_Render_Export_Mesh_As_3Dgs4Dgs_Ce2F7(bpy.types.Operator):
         layout = self.layout
         if (bpy.context.scene.sna_dgs_scene_properties.export_single_or_sequence == '4DGS'):
             box_5A7F8 = layout.box()
-            box_5A7F8.alert = False
-            box_5A7F8.enabled = True
-            box_5A7F8.active = True
-            box_5A7F8.use_property_split = False
-            box_5A7F8.use_property_decorate = False
-            box_5A7F8.alignment = 'Expand'.upper()
-            box_5A7F8.scale_x = 1.0
-            box_5A7F8.scale_y = 1.0
-            if not True: box_5A7F8.operator_context = "EXEC_DEFAULT"
             box_5A7F8.label(text='Exporting large scans as .PLY sequences is not recommended,', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
             box_5A7F8.label(text='        it can be best to export a cropped subset of points', icon_value=0)
             box_5A7F8.label(text='        Exporting large numbers of frames can take a while', icon_value=0)
         box_44942 = layout.box()
-        box_44942.alert = False
-        box_44942.enabled = True
-        box_44942.active = True
-        box_44942.use_property_split = False
-        box_44942.use_property_decorate = False
-        box_44942.alignment = 'Expand'.upper()
-        box_44942.scale_x = 1.0
-        box_44942.scale_y = 1.0
-        if not True: box_44942.operator_context = "EXEC_DEFAULT"
         box_44942.label(text='Camera updates will be set to Disabled', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_44942.label(text='        Any enabled Animate modifiers found will be set to Displace Only', icon_value=0)
         box_44942.label(text='        3DGS Transforms will be applied to the input object', icon_value=0)
         box_44942.label(text='        The World Centre will be the exported model origin', icon_value=0)
         box_2A27F = layout.box()
-        box_2A27F.alert = False
-        box_2A27F.enabled = True
-        box_2A27F.active = True
-        box_2A27F.use_property_split = False
-        box_2A27F.use_property_decorate = False
-        box_2A27F.alignment = 'Expand'.upper()
-        box_2A27F.scale_x = 1.0
-        box_2A27F.scale_y = 1.0
-        if not True: box_2A27F.operator_context = "EXEC_DEFAULT"
         box_2A27F.prop(self, 'sna_send_to_world_centre', text='Reset Position (Rig locked objects ignore this)', icon_value=0, emboss=True)
 
     def invoke(self, context, event):

--- a/src/generate_hq_object.py
+++ b/src/generate_hq_object.py
@@ -19,9 +19,9 @@ class SNA_OT_Dgs_Render_Generate_Hq_Object_55455(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         dgs_render__hq_mode['sna_lq_object_list'] = []
@@ -102,15 +102,6 @@ class SNA_OT_Dgs_Render_Generate_Hq_Object_55455(bpy.types.Operator):
     def draw(self, context):
         layout = self.layout
         box_B5524 = layout.box()
-        box_B5524.alert = False
-        box_B5524.enabled = True
-        box_B5524.active = True
-        box_B5524.use_property_split = False
-        box_B5524.use_property_decorate = False
-        box_B5524.alignment = 'Expand'.upper()
-        box_B5524.scale_x = 1.0
-        box_B5524.scale_y = 1.0
-        if not True: box_B5524.operator_context = "EXEC_DEFAULT"
         box_B5524.label(text="All original 'LQ' objects will be moved into '3DGS_LQ_Objects' collection", icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_B5524.label(text="        A new object -'KIRI_HQ_Merged_Object' - will be created", icon_value=0)
         box_B5524.label(text='        Use the LQ / HQ drop down to toggle between original and HQ object visibilities', icon_value=0)

--- a/src/hq_mode_function_interface.py
+++ b/src/hq_mode_function_interface.py
@@ -12,99 +12,27 @@ def sna_hq_mode_function_interface_17C41(layout_function, ):
         pass
     else:
         box_5B434 = layout_function.box()
-        box_5B434.alert = False
-        box_5B434.enabled = True
-        box_5B434.active = True
-        box_5B434.use_property_split = False
-        box_5B434.use_property_decorate = False
-        box_5B434.alignment = 'Expand'.upper()
-        box_5B434.scale_x = 1.0
-        box_5B434.scale_y = 1.0
-        if not True: box_5B434.operator_context = "EXEC_DEFAULT"
         box_5B434.label(text='Eevee is not enabled', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
     if (bpy.context.scene.camera == None):
         box_9AC8C = layout_function.box()
-        box_9AC8C.alert = False
-        box_9AC8C.enabled = True
-        box_9AC8C.active = True
-        box_9AC8C.use_property_split = False
-        box_9AC8C.use_property_decorate = False
-        box_9AC8C.alignment = 'Expand'.upper()
-        box_9AC8C.scale_x = 1.0
-        box_9AC8C.scale_y = 1.0
-        if not True: box_9AC8C.operator_context = "EXEC_DEFAULT"
         box_9AC8C.label(text='No Active Camera', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_9AC8C.label(text='         HQ Materials Require An Active Camera', icon_value=0)
     col_249D2 = layout_function.column(heading='', align=False)
-    col_249D2.alert = False
-    col_249D2.enabled = True
-    col_249D2.active = True
-    col_249D2.use_property_split = False
-    col_249D2.use_property_decorate = False
-    col_249D2.scale_x = 1.0
-    col_249D2.scale_y = 1.0
-    col_249D2.alignment = 'Expand'.upper()
-    col_249D2.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     if bpy.context.preferences.addons[__package__].preferences.sna_show_tips:
         box_AEE3F = col_249D2.box()
-        box_AEE3F.alert = False
-        box_AEE3F.enabled = True
-        box_AEE3F.active = True
-        box_AEE3F.use_property_split = False
-        box_AEE3F.use_property_decorate = False
-        box_AEE3F.alignment = 'Expand'.upper()
-        box_AEE3F.scale_x = 1.0
-        box_AEE3F.scale_y = 1.0
-        if not True: box_AEE3F.operator_context = "EXEC_DEFAULT"
         box_AEE3F.label(text='LQ Mode requires high samples', icon_value=0)
         box_AEE3F.label(text='Samples can be set to 1 in HQ Mode', icon_value=0)
         box_AEE3F.label(text="if 'Shadeless' materials are used", icon_value=0)
     if bpy.context.scene.eevee.use_taa_reprojection:
         box_06ADA = col_249D2.box()
-        box_06ADA.alert = False
-        box_06ADA.enabled = True
-        box_06ADA.active = True
-        box_06ADA.use_property_split = False
-        box_06ADA.use_property_decorate = False
-        box_06ADA.alignment = 'Expand'.upper()
-        box_06ADA.scale_x = 1.0
-        box_06ADA.scale_y = 1.0
-        if not True: box_06ADA.operator_context = "EXEC_DEFAULT"
         box_06ADA.label(text='Temporal Reprojection is enabled ', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_06ADA.label(text='This can cause flickering', icon_value=0)
     box_0F8BF = col_249D2.box()
-    box_0F8BF.alert = False
-    box_0F8BF.enabled = True
-    box_0F8BF.active = True
-    box_0F8BF.use_property_split = False
-    box_0F8BF.use_property_decorate = False
-    box_0F8BF.alignment = 'Expand'.upper()
-    box_0F8BF.scale_x = 1.0
-    box_0F8BF.scale_y = 1.0
-    if not True: box_0F8BF.operator_context = "EXEC_DEFAULT"
     col_E83D4 = box_0F8BF.column(heading='', align=True)
-    col_E83D4.alert = False
-    col_E83D4.enabled = True
-    col_E83D4.active = True
-    col_E83D4.use_property_split = False
-    col_E83D4.use_property_decorate = False
-    col_E83D4.scale_x = 1.0
-    col_E83D4.scale_y = 1.0
-    col_E83D4.alignment = 'Expand'.upper()
-    col_E83D4.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_E83D4.prop(bpy.context.scene.eevee, 'taa_samples', text='Eevee Viewport Samples', icon_value=0, emboss=True)
     col_E83D4.prop(bpy.context.scene.eevee, 'taa_render_samples', text='Eevee Render Samples', icon_value=0, emboss=True)
     if bpy.context.scene.eevee.use_taa_reprojection:
         box_6EA64 = col_249D2.box()
-        box_6EA64.alert = False
-        box_6EA64.enabled = True
-        box_6EA64.active = True
-        box_6EA64.use_property_split = False
-        box_6EA64.use_property_decorate = False
-        box_6EA64.alignment = 'Expand'.upper()
-        box_6EA64.scale_x = 1.0
-        box_6EA64.scale_y = 1.0
-        if not True: box_6EA64.operator_context = "EXEC_DEFAULT"
         box_6EA64.prop(bpy.context.scene.eevee, 'use_taa_reprojection', text='Temporal Reprojection', icon_value=0, emboss=True)
     col_249D2.separator(factor=1.0)
     if (bpy.context.view_layer.objects.active == None):
@@ -115,61 +43,16 @@ def sna_hq_mode_function_interface_17C41(layout_function, ):
                 pass
             else:
                 box_2E343 = col_249D2.box()
-                box_2E343.alert = False
-                box_2E343.enabled = True
-                box_2E343.active = True
-                box_2E343.use_property_split = False
-                box_2E343.use_property_decorate = False
-                box_2E343.alignment = 'Expand'.upper()
-                box_2E343.scale_x = 1.0
-                box_2E343.scale_y = 1.0
-                if not True: box_2E343.operator_context = "EXEC_DEFAULT"
                 row_19BC2 = box_2E343.row(heading='', align=False)
-                row_19BC2.alert = False
-                row_19BC2.enabled = True
-                row_19BC2.active = True
-                row_19BC2.use_property_split = False
-                row_19BC2.use_property_decorate = False
-                row_19BC2.scale_x = 1.0
-                row_19BC2.scale_y = 1.0
-                row_19BC2.alignment = 'Expand'.upper()
-                row_19BC2.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 row_19BC2.label(text=str(bpy.context.view_layer.objects.active.material_slots[i_E3C27].material.name), icon_value=0)
                 box_2E343.prop(bpy.context.view_layer.objects.active.material_slots[i_E3C27].material.sna_dgs_material_properties, 'lq_hq', text='', icon_value=0, emboss=True)
     col_249D2.separator(factor=1.0)
     box_D2847 = col_249D2.box()
-    box_D2847.alert = False
-    box_D2847.enabled = True
-    box_D2847.active = True
-    box_D2847.use_property_split = False
-    box_D2847.use_property_decorate = False
-    box_D2847.alignment = 'Expand'.upper()
-    box_D2847.scale_x = 1.0
-    box_D2847.scale_y = 1.0
-    if not True: box_D2847.operator_context = "EXEC_DEFAULT"
     box_D2847.prop(bpy.context.scene.sna_dgs_scene_properties, 'hq_overlap', text='HQ Objects Overlap', icon_value=0, emboss=True, toggle=False)
     if bpy.context.scene.sna_dgs_scene_properties.hq_overlap:
         box_0826A = col_249D2.box()
-        box_0826A.alert = False
-        box_0826A.enabled = True
-        box_0826A.active = True
-        box_0826A.use_property_split = False
-        box_0826A.use_property_decorate = False
-        box_0826A.alignment = 'Expand'.upper()
-        box_0826A.scale_x = 1.0
-        box_0826A.scale_y = 1.0
-        if not True: box_0826A.operator_context = "EXEC_DEFAULT"
         if (property_exists("bpy.context.scene.objects", globals(), locals()) and 'KIRI_HQ_Merged_Object' in bpy.context.scene.objects):
             box_BEFDD = box_0826A.box()
-            box_BEFDD.alert = False
-            box_BEFDD.enabled = False
-            box_BEFDD.active = True
-            box_BEFDD.use_property_split = False
-            box_BEFDD.use_property_decorate = False
-            box_BEFDD.alignment = 'Expand'.upper()
-            box_BEFDD.scale_x = 1.0
-            box_BEFDD.scale_y = 1.0
-            if not True: box_BEFDD.operator_context = "EXEC_DEFAULT"
             box_BEFDD.label(text='HQ Object Already Exists', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
             op = box_BEFDD.operator('sna.dgs_render_generate_hq_object_55455', text='Generate HQ Object', icon_value=0, emboss=True, depress=False)
         else:

--- a/src/image_overlay_function_interface.py
+++ b/src/image_overlay_function_interface.py
@@ -10,91 +10,29 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_image_overlay_function_interface_64796(layout_function, ):
     col_D492B = layout_function.column(heading='', align=False)
-    col_D492B.alert = False
-    col_D492B.enabled = True
-    col_D492B.active = True
-    col_D492B.use_property_split = False
-    col_D492B.use_property_decorate = False
-    col_D492B.scale_x = 1.0
-    col_D492B.scale_y = 1.0
-    col_D492B.alignment = 'Expand'.upper()
-    col_D492B.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_D492B.label(text='Image Overlay', icon_value=0)
     col_D492B.separator(factor=1.0)
     attr_F9567 = '["' + str('Socket_56' + '"]') 
     col_D492B.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_F9567), text='Enable Image Overlay', icon_value=0, emboss=True, toggle=True)
     col_D492B.separator(factor=1.0)
     col_FC5C4 = col_D492B.column(heading='', align=False)
-    col_FC5C4.alert = False
     col_FC5C4.enabled = bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_56']
-    col_FC5C4.active = True
-    col_FC5C4.use_property_split = False
-    col_FC5C4.use_property_decorate = False
-    col_FC5C4.scale_x = 1.0
-    col_FC5C4.scale_y = 1.0
-    col_FC5C4.alignment = 'Expand'.upper()
-    col_FC5C4.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     box_61F2D = col_FC5C4.box()
-    box_61F2D.alert = False
-    box_61F2D.enabled = True
-    box_61F2D.active = True
-    box_61F2D.use_property_split = False
-    box_61F2D.use_property_decorate = False
-    box_61F2D.alignment = 'Expand'.upper()
-    box_61F2D.scale_x = 1.0
-    box_61F2D.scale_y = 1.0
-    if not True: box_61F2D.operator_context = "EXEC_DEFAULT"
     row_4E69D = box_61F2D.row(heading='', align=False)
-    row_4E69D.alert = False
-    row_4E69D.enabled = True
-    row_4E69D.active = True
-    row_4E69D.use_property_split = False
-    row_4E69D.use_property_decorate = False
-    row_4E69D.scale_x = 1.0
-    row_4E69D.scale_y = 1.0
-    row_4E69D.alignment = 'Expand'.upper()
-    row_4E69D.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     row_4E69D.prop_search(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], '["Socket_60"]'), bpy.data, 'images', text='', icon='NONE', item_search_property="name")
     op = row_4E69D.operator('sna.dgs_render_import_image_overlay_4a457', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'folder.svg')), emboss=True, depress=False)
     box_EA447 = col_FC5C4.box()
-    box_EA447.alert = False
-    box_EA447.enabled = True
-    box_EA447.active = True
-    box_EA447.use_property_split = False
-    box_EA447.use_property_decorate = False
-    box_EA447.alignment = 'Expand'.upper()
-    box_EA447.scale_x = 1.0
-    box_EA447.scale_y = 1.0
-    if not True: box_EA447.operator_context = "EXEC_DEFAULT"
     box_EA447.label(text='Blend Mode', icon_value=0)
     attr_9DFC4 = '["' + str('Socket_63' + '"]') 
     box_EA447.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_9DFC4), text='', icon_value=0, emboss=True)
     attr_7BFD4 = '["' + str('Socket_61' + '"]') 
     box_EA447.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_7BFD4), text='Mix Factor', icon_value=0, emboss=True)
     box_CABC3 = col_FC5C4.box()
-    box_CABC3.alert = False
-    box_CABC3.enabled = True
-    box_CABC3.active = True
-    box_CABC3.use_property_split = False
-    box_CABC3.use_property_decorate = False
-    box_CABC3.alignment = 'Expand'.upper()
-    box_CABC3.scale_x = 1.0
-    box_CABC3.scale_y = 1.0
-    if not True: box_CABC3.operator_context = "EXEC_DEFAULT"
     box_CABC3.label(text='Image Mapping', icon_value=0)
     attr_1EE7F = '["' + str('Socket_76' + '"]') 
     box_CABC3.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_1EE7F), text='', icon_value=0, emboss=True)
     if ((bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_76'] == 0) or (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_76'] == 2)):
         box_3B9C8 = col_FC5C4.box()
-        box_3B9C8.alert = False
-        box_3B9C8.enabled = True
-        box_3B9C8.active = True
-        box_3B9C8.use_property_split = False
-        box_3B9C8.use_property_decorate = False
-        box_3B9C8.alignment = 'Expand'.upper()
-        box_3B9C8.scale_x = 1.0
-        box_3B9C8.scale_y = 1.0
-        if not True: box_3B9C8.operator_context = "EXEC_DEFAULT"
         attr_1C59C = '["' + str('Socket_82' + '"]') 
         box_3B9C8.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_1C59C), text='Location', icon_value=0, emboss=True)
         attr_18E1F = '["' + str('Socket_74' + '"]') 
@@ -103,42 +41,16 @@ def sna_image_overlay_function_interface_64796(layout_function, ):
         box_3B9C8.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_C764D), text='Scale', icon_value=0, emboss=True)
     if (bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_76'] == 1):
         box_A6BCF = col_FC5C4.box()
-        box_A6BCF.alert = False
-        box_A6BCF.enabled = True
-        box_A6BCF.active = True
-        box_A6BCF.use_property_split = False
-        box_A6BCF.use_property_decorate = False
-        box_A6BCF.alignment = 'Expand'.upper()
-        box_A6BCF.scale_x = 1.0
-        box_A6BCF.scale_y = 1.0
-        if not True: box_A6BCF.operator_context = "EXEC_DEFAULT"
         box_A6BCF.label(text='Mapping Object', icon_value=0)
         attr_47BD3 = '["' + str('Socket_77' + '"]') 
         box_A6BCF.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_47BD3), text='', icon_value=0, emboss=True)
     box_8D0CD = col_FC5C4.box()
     box_8D0CD.alert = bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_67']
-    box_8D0CD.enabled = True
-    box_8D0CD.active = True
-    box_8D0CD.use_property_split = False
-    box_8D0CD.use_property_decorate = False
-    box_8D0CD.alignment = 'Expand'.upper()
-    box_8D0CD.scale_x = 1.0
-    box_8D0CD.scale_y = 1.0
-    if not True: box_8D0CD.operator_context = "EXEC_DEFAULT"
     box_8D0CD.label(text='Masking', icon_value=0)
     attr_145C4 = '["' + str('Socket_67' + '"]') 
     box_8D0CD.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_145C4), text='Mask By Object', icon_value=0, emboss=True, toggle=True)
     if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_67']:
         col_D2C3C = box_8D0CD.column(heading='', align=False)
-        col_D2C3C.alert = False
-        col_D2C3C.enabled = True
-        col_D2C3C.active = True
-        col_D2C3C.use_property_split = False
-        col_D2C3C.use_property_decorate = False
-        col_D2C3C.scale_x = 1.0
-        col_D2C3C.scale_y = 1.0
-        col_D2C3C.alignment = 'Expand'.upper()
-        col_D2C3C.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_67BF4 = '["' + str('Socket_68' + '"]') 
         col_D2C3C.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_67BF4), text='', icon_value=0, emboss=True, toggle=True)
         attr_9154D = '["' + str('Socket_69' + '"]') 

--- a/src/import_image_overlay.py
+++ b/src/import_image_overlay.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Import_Image_Overlay_4A457(bpy.types.Operator, ImportHel
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         image_AB939 = bpy.data.images.load(filepath=self.filepath, check_existing=True, )

--- a/src/import_menu.py
+++ b/src/import_menu.py
@@ -9,110 +9,30 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_import_menu_94FB1(layout_function, ):
     col_E3544 = layout_function.column(heading='', align=False)
-    col_E3544.alert = False
-    col_E3544.enabled = True
-    col_E3544.active = True
-    col_E3544.use_property_split = False
-    col_E3544.use_property_decorate = False
-    col_E3544.scale_x = 1.0
-    col_E3544.scale_y = 1.0
-    col_E3544.alignment = 'Expand'.upper()
-    col_E3544.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     box_910F6 = col_E3544.box()
-    box_910F6.alert = False
-    box_910F6.enabled = True
-    box_910F6.active = True
-    box_910F6.use_property_split = False
-    box_910F6.use_property_decorate = False
-    box_910F6.alignment = 'Expand'.upper()
-    box_910F6.scale_x = 1.0
-    box_910F6.scale_y = 1.0
-    if not True: box_910F6.operator_context = "EXEC_DEFAULT"
     row_8F631 = box_910F6.row(heading='Import as: ', align=False)
-    row_8F631.alert = False
-    row_8F631.enabled = True
-    row_8F631.active = True
-    row_8F631.use_property_split = False
-    row_8F631.use_property_decorate = False
-    row_8F631.scale_x = 1.0
-    row_8F631.scale_y = 1.0
-    row_8F631.alignment = 'Expand'.upper()
-    row_8F631.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     row_8F631.prop(bpy.context.scene.sna_dgs_scene_properties, 'import_face_vert', text=bpy.context.scene.sna_dgs_scene_properties.import_face_vert, icon_value=0, emboss=True, expand=True, toggle=True)
     if (bpy.context.scene.sna_dgs_scene_properties.import_face_vert == 'Faces'):
         box_910F6.prop(bpy.context.scene.sna_dgs_scene_properties, 'import_uv', text='UV Reset', icon_value=0, emboss=True, toggle=False)
     box_910F6.prop(bpy.context.scene.sna_dgs_scene_properties, 'import_proxy', text='Create Proxy Object', icon_value=0, emboss=True, expand=True, toggle=False)
     box_5C3FC = col_E3544.box()
-    box_5C3FC.alert = False
-    box_5C3FC.enabled = True
-    box_5C3FC.active = True
-    box_5C3FC.use_property_split = False
-    box_5C3FC.use_property_decorate = False
-    box_5C3FC.alignment = 'Expand'.upper()
-    box_5C3FC.scale_x = 1.0
     box_5C3FC.scale_y = 2.0
-    if not True: box_5C3FC.operator_context = "EXEC_DEFAULT"
     op = box_5C3FC.operator('sna.dgs_render_import_ply_e0a3a', text='Import PLY', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'import.svg')), emboss=True, depress=False)
     if (bpy.context.view_layer.objects.active == None):
         pass
     else:
         box_0AF9B = col_E3544.box()
-        box_0AF9B.alert = False
-        box_0AF9B.enabled = True
-        box_0AF9B.active = True
-        box_0AF9B.use_property_split = False
-        box_0AF9B.use_property_decorate = False
-        box_0AF9B.alignment = 'Expand'.upper()
-        box_0AF9B.scale_x = 1.0
-        box_0AF9B.scale_y = 1.0
-        if not True: box_0AF9B.operator_context = "EXEC_DEFAULT"
         op = box_0AF9B.operator('sna.dgs_render_rotate_for_blender_axes_423de', text='Rotate Active To Blender Axes', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'refresh.svg')), emboss=True, depress=False)
     if bpy.context.preferences.addons[__package__].preferences.sna_show_tips:
         col_9F76F = col_E3544.column(heading='', align=False)
-        col_9F76F.alert = False
-        col_9F76F.enabled = True
-        col_9F76F.active = True
-        col_9F76F.use_property_split = False
-        col_9F76F.use_property_decorate = False
-        col_9F76F.scale_x = 1.0
-        col_9F76F.scale_y = 1.0
-        col_9F76F.alignment = 'Expand'.upper()
-        col_9F76F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         box_599AC = col_9F76F.box()
-        box_599AC.alert = False
-        box_599AC.enabled = True
-        box_599AC.active = True
-        box_599AC.use_property_split = False
-        box_599AC.use_property_decorate = False
-        box_599AC.alignment = 'Expand'.upper()
-        box_599AC.scale_x = 1.0
-        box_599AC.scale_y = 1.0
-        if not True: box_599AC.operator_context = "EXEC_DEFAULT"
         box_599AC.label(text='Do not apply rotation or scale', icon_value=0)
         box_599AC.label(text="using Blender's native Apply Transforms", icon_value=0)
         box_599AC.label(text="Use the addon's Apply 3DGS Transforms", icon_value=0)
         box_37F67 = col_9F76F.box()
-        box_37F67.alert = False
-        box_37F67.enabled = True
-        box_37F67.active = True
-        box_37F67.use_property_split = False
-        box_37F67.use_property_decorate = False
-        box_37F67.alignment = 'Expand'.upper()
-        box_37F67.scale_x = 1.0
-        box_37F67.scale_y = 1.0
-        if not True: box_37F67.operator_context = "EXEC_DEFAULT"
         box_37F67.label(text='Verts = performance, rigging and ', icon_value=0)
         box_37F67.label(text='visual parity with Render mode results', icon_value=0)
         box_37F67.label(text='Faces = Vertex Painting and fine edits', icon_value=0)
         if (bpy.context.scene.render.engine != 'BLENDER_EEVEE_NEXT'):
             box_3BEA2 = col_9F76F.box()
-            box_3BEA2.alert = False
-            box_3BEA2.enabled = True
-            box_3BEA2.active = True
-            box_3BEA2.use_property_split = False
-            box_3BEA2.use_property_decorate = False
-            box_3BEA2.alignment = 'Expand'.upper()
-            box_3BEA2.scale_x = 1.0
-            box_3BEA2.scale_y = 1.0
-            if not True: box_3BEA2.operator_context = "EXEC_DEFAULT"
             box_3BEA2.label(text='Eevee is recommended', icon_value=0)

--- a/src/import_ply.py
+++ b/src/import_ply.py
@@ -19,9 +19,9 @@ class SNA_OT_Dgs_Render_Import_Ply_E0A3A(bpy.types.Operator, ImportHelper):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         ply_import_path = self.filepath

--- a/src/launch_site.py
+++ b/src/launch_site.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Launch_Site_Bf973(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         url = self.sna_site_address

--- a/src/light_bake.py
+++ b/src/light_bake.py
@@ -45,6 +45,7 @@ def sna_light_bake_8F346(layout_function, ):
                 row_18A3E.prop(bpy.context.scene.sna_dgs_scene_properties, 'light_bake_active_menu', text=bpy.context.scene.sna_dgs_scene_properties.light_bake_active_menu, icon_value=0, emboss=True, expand=True)
                 if bpy.context.scene.sna_dgs_scene_properties.light_bake_active_menu == "1. Store Light":
                     col_56E5A = col_DA035.column(heading='', align=False)
+                    col_56E5A.alert = True
                     if 'proxy_deferred_relight_stage_saved' in bpy.context.view_layer.objects.active:
                         if bpy.context.view_layer.objects.active['proxy_deferred_relight_stage_saved']:
                             box_D56BA = col_56E5A.box()
@@ -62,6 +63,7 @@ def sna_light_bake_8F346(layout_function, ):
                     pass
                 box_82787 = col_DA035.box()
                 col_9B44F = box_82787.column(heading='', align=False)
+                col_9B44F.alert = True
                 op = col_9B44F.operator('sna.dgs_render_restore_original_light_9a7fe', text='Restore Lighting', icon_value=0, emboss=True, depress=False)
         else:
             box_B787A = col_3F618.box()

--- a/src/light_bake.py
+++ b/src/light_bake.py
@@ -12,86 +12,25 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_light_bake_8F346(layout_function, ):
     if (bpy.context.preferences.addons[__package__].preferences.sna_cache_file_directory == ''):
         box_923B8 = layout_function.box()
-        box_923B8.alert = False
-        box_923B8.enabled = True
-        box_923B8.active = True
-        box_923B8.use_property_split = False
-        box_923B8.use_property_decorate = False
-        box_923B8.alignment = 'Expand'.upper()
-        box_923B8.scale_x = 1.0
-        box_923B8.scale_y = 1.0
-        if not True: box_923B8.operator_context = "EXEC_DEFAULT"
         box_923B8.label(text='Cache directory is empty.', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_923B8.label(text='Set it in Preferences', icon_value=0)
     col_3F618 = layout_function.column(heading='', align=True)
-    col_3F618.alert = False
     col_3F618.enabled = (bpy.context.preferences.addons[__package__].preferences.sna_cache_file_directory != '')
-    col_3F618.active = True
-    col_3F618.use_property_split = False
-    col_3F618.use_property_decorate = False
-    col_3F618.scale_x = 1.0
-    col_3F618.scale_y = 1.0
-    col_3F618.alignment = 'Expand'.upper()
-    col_3F618.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     if (bpy.context.view_layer.objects.active == None):
         box_C7AE0 = col_3F618.box()
-        box_C7AE0.alert = False
-        box_C7AE0.enabled = True
-        box_C7AE0.active = True
-        box_C7AE0.use_property_split = False
-        box_C7AE0.use_property_decorate = False
-        box_C7AE0.alignment = 'Expand'.upper()
-        box_C7AE0.scale_x = 1.0
         box_C7AE0.scale_y = 2.0
-        if not True: box_C7AE0.operator_context = "EXEC_DEFAULT"
         box_C7AE0.label(text='No Active Object', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
     else:
         if '3DGS_Mesh_Type' in bpy.context.view_layer.objects.active:
             col_9A00F = col_3F618.column(heading='', align=False)
-            col_9A00F.alert = False
-            col_9A00F.enabled = True
-            col_9A00F.active = True
-            col_9A00F.use_property_split = False
-            col_9A00F.use_property_decorate = False
-            col_9A00F.scale_x = 1.0
-            col_9A00F.scale_y = 1.0
-            col_9A00F.alignment = 'Expand'.upper()
-            col_9A00F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             box_18E8E = col_9A00F.box()
-            box_18E8E.alert = False
-            box_18E8E.enabled = True
-            box_18E8E.active = True
-            box_18E8E.use_property_split = False
-            box_18E8E.use_property_decorate = False
-            box_18E8E.alignment = 'Expand'.upper()
-            box_18E8E.scale_x = 1.0
-            box_18E8E.scale_y = 1.0
-            if not True: box_18E8E.operator_context = "EXEC_DEFAULT"
             box_18E8E.label(text='Proxy Mesh', icon_value=0)
             row_33E8E = box_18E8E.row(heading='', align=True)
-            row_33E8E.alert = False
-            row_33E8E.enabled = True
-            row_33E8E.active = True
-            row_33E8E.use_property_split = False
-            row_33E8E.use_property_decorate = False
-            row_33E8E.scale_x = 1.0
-            row_33E8E.scale_y = 1.0
-            row_33E8E.alignment = 'Expand'.upper()
-            row_33E8E.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             row_33E8E.prop(bpy.context.view_layer.objects.active.sna_dgs_object_properties, 'rig_proxy_mesh', text='', icon_value=0, emboss=True)
             if (bpy.context.view_layer.objects.active.sna_dgs_object_properties.rig_proxy_mesh == None):
                 pass
             else:
                 row_BD7EE = row_33E8E.row(heading='', align=True)
-                row_BD7EE.alert = False
-                row_BD7EE.enabled = True
-                row_BD7EE.active = True
-                row_BD7EE.use_property_split = False
-                row_BD7EE.use_property_decorate = False
-                row_BD7EE.scale_x = 1.0
-                row_BD7EE.scale_y = 1.0
-                row_BD7EE.alignment = 'Expand'.upper()
-                row_BD7EE.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 op = row_BD7EE.operator('sna.dgs_render_select_object_b1f49', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'mouse-pointer.svg')), emboss=True, depress=False)
                 op.sna_object_name = bpy.context.view_layer.objects.active.sna_dgs_object_properties.rig_proxy_mesh.name
                 row_BD7EE.prop(bpy.context.view_layer.objects.active.sna_dgs_object_properties.rig_proxy_mesh, 'hide_viewport', text='', icon_value=0, emboss=True)
@@ -101,60 +40,17 @@ def sna_light_bake_8F346(layout_function, ):
             else:
                 col_9A00F.separator(factor=3.0)
                 col_DA035 = col_9A00F.column(heading='', align=False)
-                col_DA035.alert = False
-                col_DA035.enabled = True
-                col_DA035.active = True
-                col_DA035.use_property_split = False
-                col_DA035.use_property_decorate = False
-                col_DA035.scale_x = 1.0
-                col_DA035.scale_y = 1.0
-                col_DA035.alignment = 'Expand'.upper()
-                col_DA035.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 row_18A3E = col_DA035.row(heading='', align=False)
-                row_18A3E.alert = False
-                row_18A3E.enabled = True
-                row_18A3E.active = True
-                row_18A3E.use_property_split = False
-                row_18A3E.use_property_decorate = False
-                row_18A3E.scale_x = 1.0
                 row_18A3E.scale_y = 2.0
-                row_18A3E.alignment = 'Expand'.upper()
-                row_18A3E.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 row_18A3E.prop(bpy.context.scene.sna_dgs_scene_properties, 'light_bake_active_menu', text=bpy.context.scene.sna_dgs_scene_properties.light_bake_active_menu, icon_value=0, emboss=True, expand=True)
                 if bpy.context.scene.sna_dgs_scene_properties.light_bake_active_menu == "1. Store Light":
                     col_56E5A = col_DA035.column(heading='', align=False)
-                    col_56E5A.alert = True
-                    col_56E5A.enabled = True
-                    col_56E5A.active = True
-                    col_56E5A.use_property_split = False
-                    col_56E5A.use_property_decorate = False
-                    col_56E5A.scale_x = 1.0
-                    col_56E5A.scale_y = 1.0
-                    col_56E5A.alignment = 'Expand'.upper()
-                    col_56E5A.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                     if 'proxy_deferred_relight_stage_saved' in bpy.context.view_layer.objects.active:
                         if bpy.context.view_layer.objects.active['proxy_deferred_relight_stage_saved']:
                             box_D56BA = col_56E5A.box()
-                            box_D56BA.alert = False
-                            box_D56BA.enabled = True
-                            box_D56BA.active = True
-                            box_D56BA.use_property_split = False
-                            box_D56BA.use_property_decorate = False
-                            box_D56BA.alignment = 'Expand'.upper()
-                            box_D56BA.scale_x = 1.0
-                            box_D56BA.scale_y = 1.0
-                            if not True: box_D56BA.operator_context = "EXEC_DEFAULT"
                             box_D56BA.label(text='Light data has previously been saved', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
                     col_305D8 = col_56E5A.column(heading='', align=False)
-                    col_305D8.alert = False
-                    col_305D8.enabled = True
-                    col_305D8.active = True
-                    col_305D8.use_property_split = False
-                    col_305D8.use_property_decorate = False
-                    col_305D8.scale_x = 1.0
                     col_305D8.scale_y = 2.0
-                    col_305D8.alignment = 'Expand'.upper()
-                    col_305D8.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                     op = col_305D8.operator('sna.dgs_render_store_original_lighting_99939', text='Store Original Lighting', icon_value=0, emboss=True, depress=False)
                 elif bpy.context.scene.sna_dgs_scene_properties.light_bake_active_menu == "2. Bake Light":
                     layout_function = col_DA035
@@ -165,35 +61,9 @@ def sna_light_bake_8F346(layout_function, ):
                 else:
                     pass
                 box_82787 = col_DA035.box()
-                box_82787.alert = False
-                box_82787.enabled = True
-                box_82787.active = True
-                box_82787.use_property_split = False
-                box_82787.use_property_decorate = False
-                box_82787.alignment = 'Expand'.upper()
-                box_82787.scale_x = 1.0
-                box_82787.scale_y = 1.0
-                if not True: box_82787.operator_context = "EXEC_DEFAULT"
                 col_9B44F = box_82787.column(heading='', align=False)
-                col_9B44F.alert = True
-                col_9B44F.enabled = True
-                col_9B44F.active = True
-                col_9B44F.use_property_split = False
-                col_9B44F.use_property_decorate = False
-                col_9B44F.scale_x = 1.0
-                col_9B44F.scale_y = 1.0
-                col_9B44F.alignment = 'Expand'.upper()
-                col_9B44F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 op = col_9B44F.operator('sna.dgs_render_restore_original_light_9a7fe', text='Restore Lighting', icon_value=0, emboss=True, depress=False)
         else:
             box_B787A = col_3F618.box()
-            box_B787A.alert = False
-            box_B787A.enabled = True
-            box_B787A.active = True
-            box_B787A.use_property_split = False
-            box_B787A.use_property_decorate = False
-            box_B787A.alignment = 'Expand'.upper()
-            box_B787A.scale_x = 1.0
             box_B787A.scale_y = 2.0
-            if not True: box_B787A.operator_context = "EXEC_DEFAULT"
             box_B787A.label(text='The Active Object is not a 3DGS Mesh', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))

--- a/src/light_bake_apply.py
+++ b/src/light_bake_apply.py
@@ -13,48 +13,13 @@ def sna_light_bake_apply_A5653(layout_function, ):
             pass
         else:
             box_FAC0D = layout_function.box()
-            box_FAC0D.alert = False
-            box_FAC0D.enabled = True
-            box_FAC0D.active = True
-            box_FAC0D.use_property_split = False
-            box_FAC0D.use_property_decorate = False
-            box_FAC0D.alignment = 'Expand'.upper()
-            box_FAC0D.scale_x = 1.0
-            box_FAC0D.scale_y = 1.0
-            if not True: box_FAC0D.operator_context = "EXEC_DEFAULT"
             box_FAC0D.label(text='Bake light data before applying', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
     else:
         box_C3353 = layout_function.box()
-        box_C3353.alert = False
-        box_C3353.enabled = True
-        box_C3353.active = True
-        box_C3353.use_property_split = False
-        box_C3353.use_property_decorate = False
-        box_C3353.alignment = 'Expand'.upper()
-        box_C3353.scale_x = 1.0
-        box_C3353.scale_y = 1.0
-        if not True: box_C3353.operator_context = "EXEC_DEFAULT"
         box_C3353.label(text='Bake light data before applying', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
     box_FCA92 = layout_function.box()
-    box_FCA92.alert = False
-    box_FCA92.enabled = True
-    box_FCA92.active = True
-    box_FCA92.use_property_split = False
-    box_FCA92.use_property_decorate = False
-    box_FCA92.alignment = 'Expand'.upper()
-    box_FCA92.scale_x = 1.0
-    box_FCA92.scale_y = 1.0
-    if not True: box_FCA92.operator_context = "EXEC_DEFAULT"
     box_FCA92.label(text='Light Pass Mix', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
     col_55C97 = box_FCA92.column(heading='', align=True)
-    col_55C97.alert = False
-    col_55C97.enabled = True
-    col_55C97.active = True
-    col_55C97.use_property_split = False
-    col_55C97.use_property_decorate = False
-    col_55C97.scale_x = 1.0
-    col_55C97.scale_y = 1.0
-    col_55C97.alignment = 'Expand'.upper()
     col_55C97.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
     col_55C97.prop(bpy.context.scene.sna_dgs_scene_properties, 'indirect_strength', text='Indirect Strength', icon_value=0, emboss=True)
     col_55C97.prop(bpy.context.scene.sna_dgs_scene_properties, 'direct_strength', text='Direct Strength', icon_value=0, emboss=True)
@@ -62,143 +27,39 @@ def sna_light_bake_apply_A5653(layout_function, ):
     col_55C97.prop(bpy.context.scene.sna_dgs_scene_properties, 'shadow_strength', text='Shadow Strength', icon_value=0, emboss=True)
     if (bpy.context.scene.sna_dgs_scene_properties.relight_include_world_environment or bpy.context.scene.sna_dgs_scene_properties.relight_include_scene_lights):
         col_2D53F = layout_function.column(heading='', align=True)
-        col_2D53F.alert = False
-        col_2D53F.enabled = True
-        col_2D53F.active = True
-        col_2D53F.use_property_split = False
-        col_2D53F.use_property_decorate = False
-        col_2D53F.scale_x = 1.0
-        col_2D53F.scale_y = 1.0
-        col_2D53F.alignment = 'Expand'.upper()
-        col_2D53F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         box_C2FE8 = col_2D53F.box()
-        box_C2FE8.alert = False
-        box_C2FE8.enabled = True
-        box_C2FE8.active = True
-        box_C2FE8.use_property_split = False
-        box_C2FE8.use_property_decorate = False
-        box_C2FE8.alignment = 'Expand'.upper()
-        box_C2FE8.scale_x = 1.0
-        box_C2FE8.scale_y = 1.0
-        if not True: box_C2FE8.operator_context = "EXEC_DEFAULT"
         col_A17CD = box_C2FE8.column(heading='', align=True)
-        col_A17CD.alert = False
-        col_A17CD.enabled = True
-        col_A17CD.active = True
-        col_A17CD.use_property_split = False
-        col_A17CD.use_property_decorate = False
-        col_A17CD.scale_x = 1.0
-        col_A17CD.scale_y = 1.0
-        col_A17CD.alignment = 'Expand'.upper()
         col_A17CD.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
         col_A17CD.label(text='Color Mix', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
         split_C326C = col_A17CD.split(factor=0.5, align=False)
-        split_C326C.alert = False
-        split_C326C.enabled = True
-        split_C326C.active = True
-        split_C326C.use_property_split = False
-        split_C326C.use_property_decorate = False
-        split_C326C.scale_x = 1.0
-        split_C326C.scale_y = 1.0
-        split_C326C.alignment = 'Expand'.upper()
-        if not True: split_C326C.operator_context = "EXEC_DEFAULT"
         split_C326C.label(text='Factor Curve', icon_value=0)
         split_C326C.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_factor_curve_mode', text='', icon_value=0, emboss=True)
         split_AB173 = col_A17CD.split(factor=0.5, align=False)
-        split_AB173.alert = False
-        split_AB173.enabled = True
-        split_AB173.active = True
-        split_AB173.use_property_split = False
-        split_AB173.use_property_decorate = False
-        split_AB173.scale_x = 1.0
-        split_AB173.scale_y = 1.0
-        split_AB173.alignment = 'Expand'.upper()
-        if not True: split_AB173.operator_context = "EXEC_DEFAULT"
         split_AB173.label(text='Factor Mode', icon_value=0)
         split_AB173.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_lighting_factor_mode', text='', icon_value=0, emboss=True)
         if (bpy.context.scene.sna_dgs_scene_properties.relight_lighting_factor_mode == 'Luminance'):
             pass
         else:
             col_D67D0 = col_A17CD.column(heading='', align=True)
-            col_D67D0.alert = False
-            col_D67D0.enabled = True
-            col_D67D0.active = True
-            col_D67D0.use_property_split = False
-            col_D67D0.use_property_decorate = False
-            col_D67D0.scale_x = 1.0
-            col_D67D0.scale_y = 1.0
-            col_D67D0.alignment = 'Expand'.upper()
             col_D67D0.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
             col_D67D0.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_colorize_mix', text='Color Mix', icon_value=0, emboss=True)
             split_18C65 = col_D67D0.split(factor=0.4000000059604645, align=True)
-            split_18C65.alert = False
-            split_18C65.enabled = True
-            split_18C65.active = True
-            split_18C65.use_property_split = False
-            split_18C65.use_property_decorate = False
-            split_18C65.scale_x = 1.0
-            split_18C65.scale_y = 1.0
-            split_18C65.alignment = 'Expand'.upper()
-            if not True: split_18C65.operator_context = "EXEC_DEFAULT"
             split_18C65.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_max_color_tint', text='Max Tint', icon_value=0, emboss=True)
             split_18C65.prop(bpy.context.scene.sna_dgs_scene_properties, 'max_color_tint_mode', text='', icon_value=0, emboss=True)
         box_85BFD = col_2D53F.box()
-        box_85BFD.alert = False
-        box_85BFD.enabled = True
-        box_85BFD.active = True
-        box_85BFD.use_property_split = False
-        box_85BFD.use_property_decorate = False
-        box_85BFD.alignment = 'Expand'.upper()
-        box_85BFD.scale_x = 1.0
-        box_85BFD.scale_y = 1.0
-        if not True: box_85BFD.operator_context = "EXEC_DEFAULT"
         box_85BFD.label(text='Global Strength', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
         col_B19E2 = box_85BFD.column(heading='', align=True)
-        col_B19E2.alert = False
-        col_B19E2.enabled = True
-        col_B19E2.active = True
-        col_B19E2.use_property_split = False
-        col_B19E2.use_property_decorate = False
-        col_B19E2.scale_x = 1.0
-        col_B19E2.scale_y = 1.0
-        col_B19E2.alignment = 'Expand'.upper()
         col_B19E2.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
         col_B19E2.prop(bpy.context.scene.sna_dgs_scene_properties, 'ambient_floor', text='Ambient Base', icon_value=0, emboss=True)
         col_B19E2.prop(bpy.context.scene.sna_dgs_scene_properties, 'light_gain', text='Light Gain', icon_value=0, emboss=True)
         col_B19E2.prop(bpy.context.scene.sna_dgs_scene_properties, 'light_power', text='Light Contrast', icon_value=0, emboss=True)
         col_B19E2.prop(bpy.context.scene.sna_dgs_scene_properties, 'max_light_factor', text='Max Light Factor', icon_value=0, emboss=True)
         box_51F49 = col_2D53F.box()
-        box_51F49.alert = False
-        box_51F49.enabled = True
-        box_51F49.active = True
-        box_51F49.use_property_split = False
-        box_51F49.use_property_decorate = False
-        box_51F49.alignment = 'Expand'.upper()
-        box_51F49.scale_x = 1.0
-        box_51F49.scale_y = 1.0
-        if not True: box_51F49.operator_context = "EXEC_DEFAULT"
         box_51F49.label(text='SH Updates', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
         col_57EA1 = box_51F49.column(heading='', align=True)
-        col_57EA1.alert = False
-        col_57EA1.enabled = True
-        col_57EA1.active = True
-        col_57EA1.use_property_split = False
-        col_57EA1.use_property_decorate = False
-        col_57EA1.scale_x = 1.0
-        col_57EA1.scale_y = 1.0
-        col_57EA1.alignment = 'Expand'.upper()
-        col_57EA1.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         col_57EA1.prop(bpy.context.scene.sna_dgs_scene_properties, 'export_mode', text='', icon_value=0, emboss=True)
         if (bpy.context.scene.sna_dgs_scene_properties.export_mode == 'Dampen Original SH'):
             col_57EA1.prop(bpy.context.scene.sna_dgs_scene_properties, 'directionality_strength', text='SH Strength', icon_value=0, emboss=True)
         box_BBA23 = col_2D53F.box()
-        box_BBA23.alert = False
-        box_BBA23.enabled = True
-        box_BBA23.active = True
-        box_BBA23.use_property_split = False
-        box_BBA23.use_property_decorate = False
-        box_BBA23.alignment = 'Expand'.upper()
-        box_BBA23.scale_x = 1.0
         box_BBA23.scale_y = 2.0
-        if not True: box_BBA23.operator_context = "EXEC_DEFAULT"
         op = box_BBA23.operator('sna.dgs_render_apply_light_data_6c5ad', text='Apply Lighting', icon_value=0, emboss=True, depress=False)

--- a/src/light_bake_apply.py
+++ b/src/light_bake_apply.py
@@ -20,7 +20,6 @@ def sna_light_bake_apply_A5653(layout_function, ):
     box_FCA92 = layout_function.box()
     box_FCA92.label(text='Light Pass Mix', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
     col_55C97 = box_FCA92.column(heading='', align=True)
-    col_55C97.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
     col_55C97.prop(bpy.context.scene.sna_dgs_scene_properties, 'indirect_strength', text='Indirect Strength', icon_value=0, emboss=True)
     col_55C97.prop(bpy.context.scene.sna_dgs_scene_properties, 'direct_strength', text='Direct Strength', icon_value=0, emboss=True)
     col_55C97.prop(bpy.context.scene.sna_dgs_scene_properties, 'occlusion_strength', text='Occlusion Strength', icon_value=0, emboss=True)
@@ -29,7 +28,6 @@ def sna_light_bake_apply_A5653(layout_function, ):
         col_2D53F = layout_function.column(heading='', align=True)
         box_C2FE8 = col_2D53F.box()
         col_A17CD = box_C2FE8.column(heading='', align=True)
-        col_A17CD.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
         col_A17CD.label(text='Color Mix', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
         split_C326C = col_A17CD.split(factor=0.5, align=False)
         split_C326C.label(text='Factor Curve', icon_value=0)
@@ -41,7 +39,6 @@ def sna_light_bake_apply_A5653(layout_function, ):
             pass
         else:
             col_D67D0 = col_A17CD.column(heading='', align=True)
-            col_D67D0.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
             col_D67D0.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_colorize_mix', text='Color Mix', icon_value=0, emboss=True)
             split_18C65 = col_D67D0.split(factor=0.4000000059604645, align=True)
             split_18C65.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_max_color_tint', text='Max Tint', icon_value=0, emboss=True)
@@ -49,7 +46,6 @@ def sna_light_bake_apply_A5653(layout_function, ):
         box_85BFD = col_2D53F.box()
         box_85BFD.label(text='Global Strength', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
         col_B19E2 = box_85BFD.column(heading='', align=True)
-        col_B19E2.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
         col_B19E2.prop(bpy.context.scene.sna_dgs_scene_properties, 'ambient_floor', text='Ambient Base', icon_value=0, emboss=True)
         col_B19E2.prop(bpy.context.scene.sna_dgs_scene_properties, 'light_gain', text='Light Gain', icon_value=0, emboss=True)
         col_B19E2.prop(bpy.context.scene.sna_dgs_scene_properties, 'light_power', text='Light Contrast', icon_value=0, emboss=True)

--- a/src/light_bake_build.py
+++ b/src/light_bake_build.py
@@ -17,7 +17,6 @@ def sna_light_bake_build_8B9DD(layout_function, ):
         col_AD78B = layout_function.column(heading='', align=True)
         box_4882E = col_AD78B.box()
         col_3E710 = box_4882E.column(heading='', align=True)
-        col_3E710.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
         col_3E710.label(text='Interpolation', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
         col_3E710.prop(bpy.context.scene.sna_dgs_scene_properties, 'normal_smoothing', text='Proxy Normal Smoothing', icon_value=0, emboss=True)
         col_3E710.prop(bpy.context.scene.sna_dgs_scene_properties, 'pre_light_smoothing', text='Pre-Light Smoothing', icon_value=0, emboss=True)
@@ -32,7 +31,6 @@ def sna_light_bake_build_8B9DD(layout_function, ):
         if bpy.context.scene.sna_dgs_scene_properties.relight_include_world_environment:
             box_018E2 = col_AD78B.box()
             col_12C25 = box_018E2.column(heading='', align=True)
-            col_12C25.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
             col_12C25.label(text='World Light', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
             col_12C25.prop(bpy.context.scene.sna_dgs_scene_properties, 'hdri_max_width', text='HDRI Max Width', icon_value=0, emboss=True)
             col_12C25.prop(bpy.context.scene.sna_dgs_scene_properties, 'irradiance_resolution', text='Irradiance Resolution', icon_value=0, emboss=True)
@@ -50,7 +48,6 @@ def sna_light_bake_build_8B9DD(layout_function, ):
         if bpy.context.scene.sna_dgs_scene_properties.relight_include_scene_lights:
             box_8F86C = col_AD78B.box()
             col_548B3 = box_8F86C.column(heading='', align=True)
-            col_548B3.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
             col_548B3.label(text='Light Objects', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
             col_548B3.prop(bpy.context.scene.sna_dgs_scene_properties, 'include_hidden_lights', text='Include Hidden Lights', icon_value=0, emboss=True)
             col_548B3.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_scene_light_gain', text='Light Gain', icon_value=0, emboss=True)

--- a/src/light_bake_build.py
+++ b/src/light_bake_build.py
@@ -9,73 +9,20 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_light_bake_build_8B9DD(layout_function, ):
     box_90A4F = layout_function.box()
-    box_90A4F.alert = False
-    box_90A4F.enabled = True
-    box_90A4F.active = True
-    box_90A4F.use_property_split = False
-    box_90A4F.use_property_decorate = False
-    box_90A4F.alignment = 'Expand'.upper()
-    box_90A4F.scale_x = 1.0
-    box_90A4F.scale_y = 1.0
-    if not True: box_90A4F.operator_context = "EXEC_DEFAULT"
     box_90A4F.label(text='Include', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
     row_095CC = box_90A4F.row(heading='', align=False)
-    row_095CC.alert = False
-    row_095CC.enabled = True
-    row_095CC.active = True
-    row_095CC.use_property_split = False
-    row_095CC.use_property_decorate = False
-    row_095CC.scale_x = 1.0
-    row_095CC.scale_y = 1.0
-    row_095CC.alignment = 'Expand'.upper()
-    row_095CC.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     row_095CC.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_include_world_environment', text='World', icon_value=0, emboss=True)
     row_095CC.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_include_scene_lights', text='Light Objects', icon_value=0, emboss=True)
     if (bpy.context.scene.sna_dgs_scene_properties.relight_include_world_environment or bpy.context.scene.sna_dgs_scene_properties.relight_include_scene_lights):
         col_AD78B = layout_function.column(heading='', align=True)
-        col_AD78B.alert = False
-        col_AD78B.enabled = True
-        col_AD78B.active = True
-        col_AD78B.use_property_split = False
-        col_AD78B.use_property_decorate = False
-        col_AD78B.scale_x = 1.0
-        col_AD78B.scale_y = 1.0
-        col_AD78B.alignment = 'Expand'.upper()
-        col_AD78B.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         box_4882E = col_AD78B.box()
-        box_4882E.alert = False
-        box_4882E.enabled = True
-        box_4882E.active = True
-        box_4882E.use_property_split = False
-        box_4882E.use_property_decorate = False
-        box_4882E.alignment = 'Expand'.upper()
-        box_4882E.scale_x = 1.0
-        box_4882E.scale_y = 1.0
-        if not True: box_4882E.operator_context = "EXEC_DEFAULT"
         col_3E710 = box_4882E.column(heading='', align=True)
-        col_3E710.alert = False
-        col_3E710.enabled = True
-        col_3E710.active = True
-        col_3E710.use_property_split = False
-        col_3E710.use_property_decorate = False
-        col_3E710.scale_x = 1.0
-        col_3E710.scale_y = 1.0
-        col_3E710.alignment = 'Expand'.upper()
         col_3E710.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
         col_3E710.label(text='Interpolation', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
         col_3E710.prop(bpy.context.scene.sna_dgs_scene_properties, 'normal_smoothing', text='Proxy Normal Smoothing', icon_value=0, emboss=True)
         col_3E710.prop(bpy.context.scene.sna_dgs_scene_properties, 'pre_light_smoothing', text='Pre-Light Smoothing', icon_value=0, emboss=True)
         col_3E710.prop(bpy.context.scene.sna_dgs_scene_properties, 'post_light_smoothing', text='Post-Light Smoothing', icon_value=0, emboss=True)
         split_755B4 = col_3E710.split(factor=0.5, align=False)
-        split_755B4.alert = False
-        split_755B4.enabled = True
-        split_755B4.active = True
-        split_755B4.use_property_split = False
-        split_755B4.use_property_decorate = False
-        split_755B4.scale_x = 1.0
-        split_755B4.scale_y = 1.0
-        split_755B4.alignment = 'Expand'.upper()
-        if not True: split_755B4.operator_context = "EXEC_DEFAULT"
         split_755B4.label(text='Transfer Style', icon_value=0)
         split_755B4.prop(bpy.context.scene.sna_dgs_scene_properties, 'transfer_style', text='', icon_value=0, emboss=True)
         if (bpy.context.scene.sna_dgs_scene_properties.transfer_style == 'Accurate'):
@@ -84,24 +31,7 @@ def sna_light_bake_build_8B9DD(layout_function, ):
             col_3E710.prop(bpy.context.scene.sna_dgs_scene_properties, 'transfer_smoothness', text='Transfer Smoothness', icon_value=0, emboss=True)
         if bpy.context.scene.sna_dgs_scene_properties.relight_include_world_environment:
             box_018E2 = col_AD78B.box()
-            box_018E2.alert = False
-            box_018E2.enabled = True
-            box_018E2.active = True
-            box_018E2.use_property_split = False
-            box_018E2.use_property_decorate = False
-            box_018E2.alignment = 'Expand'.upper()
-            box_018E2.scale_x = 1.0
-            box_018E2.scale_y = 1.0
-            if not True: box_018E2.operator_context = "EXEC_DEFAULT"
             col_12C25 = box_018E2.column(heading='', align=True)
-            col_12C25.alert = False
-            col_12C25.enabled = True
-            col_12C25.active = True
-            col_12C25.use_property_split = False
-            col_12C25.use_property_decorate = False
-            col_12C25.scale_x = 1.0
-            col_12C25.scale_y = 1.0
-            col_12C25.alignment = 'Expand'.upper()
             col_12C25.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
             col_12C25.label(text='World Light', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
             col_12C25.prop(bpy.context.scene.sna_dgs_scene_properties, 'hdri_max_width', text='HDRI Max Width', icon_value=0, emboss=True)
@@ -110,51 +40,16 @@ def sna_light_bake_build_8B9DD(layout_function, ):
             col_12C25.prop(bpy.context.scene.sna_dgs_scene_properties, 'irradiance_luminance_clamp', text='Irradiance Clamp', icon_value=0, emboss=True)
         if bpy.context.scene.sna_dgs_scene_properties.relight_include_world_environment:
             box_10AE9 = col_AD78B.box()
-            box_10AE9.alert = False
-            box_10AE9.enabled = True
-            box_10AE9.active = True
-            box_10AE9.use_property_split = False
-            box_10AE9.use_property_decorate = False
-            box_10AE9.alignment = 'Expand'.upper()
-            box_10AE9.scale_x = 1.0
-            box_10AE9.scale_y = 1.0
-            if not True: box_10AE9.operator_context = "EXEC_DEFAULT"
             box_10AE9.label(text='World Occlusion', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
             box_10AE9.prop(bpy.context.scene.sna_dgs_scene_properties, 'use_proxy_occlusion', text='Enable Proxy Occlusion', icon_value=0, emboss=True)
             if bpy.context.scene.sna_dgs_scene_properties.use_proxy_occlusion:
                 col_803AA = box_10AE9.column(heading='', align=True)
-                col_803AA.alert = False
-                col_803AA.enabled = True
-                col_803AA.active = True
-                col_803AA.use_property_split = False
-                col_803AA.use_property_decorate = False
-                col_803AA.scale_x = 1.0
-                col_803AA.scale_y = 1.0
-                col_803AA.alignment = 'Expand'.upper()
-                col_803AA.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 col_803AA.prop(bpy.context.scene.sna_dgs_scene_properties, 'occlusion_sample_count', text='Occlusion sample count', icon_value=0, emboss=True)
                 col_803AA.prop(bpy.context.scene.sna_dgs_scene_properties, 'occlusion_bias', text='Occlusion bias', icon_value=0, emboss=True)
                 col_803AA.prop(bpy.context.scene.sna_dgs_scene_properties, 'occlusion_max_distance', text='Occlusion Max Distance', icon_value=0, emboss=True)
         if bpy.context.scene.sna_dgs_scene_properties.relight_include_scene_lights:
             box_8F86C = col_AD78B.box()
-            box_8F86C.alert = False
-            box_8F86C.enabled = True
-            box_8F86C.active = True
-            box_8F86C.use_property_split = False
-            box_8F86C.use_property_decorate = False
-            box_8F86C.alignment = 'Expand'.upper()
-            box_8F86C.scale_x = 1.0
-            box_8F86C.scale_y = 1.0
-            if not True: box_8F86C.operator_context = "EXEC_DEFAULT"
             col_548B3 = box_8F86C.column(heading='', align=True)
-            col_548B3.alert = False
-            col_548B3.enabled = True
-            col_548B3.active = True
-            col_548B3.use_property_split = False
-            col_548B3.use_property_decorate = False
-            col_548B3.scale_x = 1.0
-            col_548B3.scale_y = 1.0
-            col_548B3.alignment = 'Expand'.upper()
             col_548B3.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
             col_548B3.label(text='Light Objects', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
             col_548B3.prop(bpy.context.scene.sna_dgs_scene_properties, 'include_hidden_lights', text='Include Hidden Lights', icon_value=0, emboss=True)
@@ -162,13 +57,5 @@ def sna_light_bake_build_8B9DD(layout_function, ):
             col_548B3.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_use_light_shadows', text='Light Object Shadows', icon_value=0, emboss=True)
             col_548B3.prop(bpy.context.scene.sna_dgs_scene_properties, 'light_shadow_bias', text='Light Object Shadow Bias', icon_value=0, emboss=True)
         box_A44FD = col_AD78B.box()
-        box_A44FD.alert = False
-        box_A44FD.enabled = True
-        box_A44FD.active = True
-        box_A44FD.use_property_split = False
-        box_A44FD.use_property_decorate = False
-        box_A44FD.alignment = 'Expand'.upper()
-        box_A44FD.scale_x = 1.0
         box_A44FD.scale_y = 2.0
-        if not True: box_A44FD.operator_context = "EXEC_DEFAULT"
         op = box_A44FD.operator('sna.dgs_render_build_light_data_ab375', text='Bake Light Data', icon_value=0, emboss=True, depress=False)

--- a/src/mesh23dgs.py
+++ b/src/mesh23dgs.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Mesh23Dgs_3Dfed(bpy.types.Operator, ImportHelper):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         if bpy.context.scene.sna_dgs_scene_properties.mesh2gs_validate:

--- a/src/mesh_to_3dgs_function_interface.py
+++ b/src/mesh_to_3dgs_function_interface.py
@@ -10,38 +10,11 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_mesh_to_3dgs_function_interface_8DDDC(layout_function, ):
     if bpy.context.preferences.addons[__package__].preferences.sna_show_tips:
         box_58AE4 = layout_function.box()
-        box_58AE4.alert = False
-        box_58AE4.enabled = True
-        box_58AE4.active = True
-        box_58AE4.use_property_split = False
-        box_58AE4.use_property_decorate = False
-        box_58AE4.alignment = 'Expand'.upper()
-        box_58AE4.scale_x = 1.0
-        box_58AE4.scale_y = 1.0
-        if not True: box_58AE4.operator_context = "EXEC_DEFAULT"
         box_58AE4.label(text='Linux and Mac are not supported', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_58AE4.label(text='         The .OBJ mesh must be triangulated', icon_value=0)
         box_58AE4.label(text='         The colour image texture must be', icon_value=0)
         box_58AE4.label(text='         in the same folder as your .OBJ and .MTL', icon_value=0)
     box_9766A = layout_function.box()
-    box_9766A.alert = False
-    box_9766A.enabled = True
-    box_9766A.active = True
-    box_9766A.use_property_split = False
-    box_9766A.use_property_decorate = False
-    box_9766A.alignment = 'Expand'.upper()
-    box_9766A.scale_x = 1.0
-    box_9766A.scale_y = 1.0
-    if not True: box_9766A.operator_context = "EXEC_DEFAULT"
     box_9766A.prop(bpy.context.scene.sna_dgs_scene_properties, 'mesh2gs_validate', text='Validate Mesh, Texture and .MTL', icon_value=0, emboss=True)
     box_8C171 = layout_function.box()
-    box_8C171.alert = False
-    box_8C171.enabled = True
-    box_8C171.active = True
-    box_8C171.use_property_split = False
-    box_8C171.use_property_decorate = False
-    box_8C171.alignment = 'Expand'.upper()
-    box_8C171.scale_x = 1.0
-    box_8C171.scale_y = 1.0
-    if not True: box_8C171.operator_context = "EXEC_DEFAULT"
     op = box_8C171.operator('sna.dgs_render_mesh23dgs_3dfed', text='Select .OBJ', icon_value=0, emboss=True, depress=False)

--- a/src/modify_menu.py
+++ b/src/modify_menu.py
@@ -18,38 +18,11 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_modify_menu_AEA26(layout_function, ):
     box_A4C5D = layout_function.box()
-    box_A4C5D.alert = False
-    box_A4C5D.enabled = True
-    box_A4C5D.active = True
-    box_A4C5D.use_property_split = False
-    box_A4C5D.use_property_decorate = False
-    box_A4C5D.alignment = 'Expand'.upper()
-    box_A4C5D.scale_x = 1.0
-    box_A4C5D.scale_y = 1.0
-    if not True: box_A4C5D.operator_context = "EXEC_DEFAULT"
     op = box_A4C5D.operator('sna.dgs_render_remove_higher_sh_attributes_cb703', text='Remove SH Attributes', icon_value=0, emboss=True, depress=False)
     box_0B550 = layout_function.box()
-    box_0B550.alert = False
-    box_0B550.enabled = True
-    box_0B550.active = True
-    box_0B550.use_property_split = False
-    box_0B550.use_property_decorate = False
-    box_0B550.alignment = 'Expand'.upper()
-    box_0B550.scale_x = 1.0
-    box_0B550.scale_y = 1.0
-    if not True: box_0B550.operator_context = "EXEC_DEFAULT"
     layout_function = box_0B550
     sna_append_wire_primitives_15D73(layout_function, )
     col_5374E = layout_function.column(heading='', align=False)
-    col_5374E.alert = False
-    col_5374E.enabled = True
-    col_5374E.active = True
-    col_5374E.use_property_split = False
-    col_5374E.use_property_decorate = False
-    col_5374E.scale_x = 1.0
-    col_5374E.scale_y = 1.0
-    col_5374E.alignment = 'Expand'.upper()
-    col_5374E.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     layout_function = col_5374E
     sna_camera_cull_8069C(layout_function, )
     layout_function = col_5374E

--- a/src/open_output_folder.py
+++ b/src/open_output_folder.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Open_Output_Folder_82000(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         folder_path = self.sna_path

--- a/src/r2_cleanup_menu.py
+++ b/src/r2_cleanup_menu.py
@@ -9,14 +9,5 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_r2_cleanup_menu_09B59(layout_function, ):
     box_64A1D = layout_function.box()
-    box_64A1D.alert = False
-    box_64A1D.enabled = True
-    box_64A1D.active = True
-    box_64A1D.use_property_split = False
-    box_64A1D.use_property_decorate = False
-    box_64A1D.alignment = 'Expand'.upper()
-    box_64A1D.scale_x = 1.0
-    box_64A1D.scale_y = 1.0
-    if not True: box_64A1D.operator_context = "EXEC_DEFAULT"
     box_64A1D.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_clear_empties', text='Delete All Proxy Empties', icon_value=0, emboss=True)
     op = box_64A1D.operator('sna.dgs_render_clean_up_scene_80052', text='Clean Up Scene', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'trash.svg')), emboss=True, depress=False)

--- a/src/r2_create_menu.py
+++ b/src/r2_create_menu.py
@@ -9,35 +9,9 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_r2_create_menu_03F72(layout_function, ):
     col_1D306 = layout_function.column(heading='', align=False)
-    col_1D306.alert = False
-    col_1D306.enabled = True
-    col_1D306.active = True
-    col_1D306.use_property_split = False
-    col_1D306.use_property_decorate = False
-    col_1D306.scale_x = 1.0
-    col_1D306.scale_y = 1.0
-    col_1D306.alignment = 'Expand'.upper()
-    col_1D306.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     box_B3EB2 = col_1D306.box()
-    box_B3EB2.alert = False
     box_B3EB2.enabled = (not (bpy.context.view_layer.objects.active == None))
-    box_B3EB2.active = True
-    box_B3EB2.use_property_split = False
-    box_B3EB2.use_property_decorate = False
-    box_B3EB2.alignment = 'Expand'.upper()
-    box_B3EB2.scale_x = 1.0
-    box_B3EB2.scale_y = 1.0
-    if not True: box_B3EB2.operator_context = "EXEC_DEFAULT"
     op = box_B3EB2.operator('sna.dgs_render_create_proxy_from_mesh_eafbb', text='Create Proxy From Visible Active Object', icon_value=0, emboss=True, depress=False)
     if (bpy.context.view_layer.objects.active == None):
         box_8209B = col_1D306.box()
-        box_8209B.alert = False
-        box_8209B.enabled = True
-        box_8209B.active = True
-        box_8209B.use_property_split = False
-        box_8209B.use_property_decorate = False
-        box_8209B.alignment = 'Expand'.upper()
-        box_8209B.scale_x = 1.0
-        box_8209B.scale_y = 1.0
-        if not True: box_8209B.operator_context = "EXEC_DEFAULT"
         box_8209B.label(text='No Active Object', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))

--- a/src/r2_render_menu.py
+++ b/src/r2_render_menu.py
@@ -10,15 +10,6 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_r2_render_menu_7AD0F(layout_function, ):
     box_3D205 = layout_function.box()
-    box_3D205.alert = False
-    box_3D205.enabled = True
-    box_3D205.active = True
-    box_3D205.use_property_split = False
-    box_3D205.use_property_decorate = False
-    box_3D205.alignment = 'Expand'.upper()
-    box_3D205.scale_x = 1.0
-    box_3D205.scale_y = 1.0
-    if not True: box_3D205.operator_context = "EXEC_DEFAULT"
     box_3D205.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_sh_degree', text='SH Degrees', icon_value=0, emboss=True)
     box_3D205.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_animation', text='Render Animation', icon_value=0, emboss=True)
     box_3D205.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_color', text='Export Color Pass', icon_value=0, emboss=True)
@@ -73,79 +64,27 @@ def sna_r2_render_menu_7AD0F(layout_function, ):
             relight_box.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_shadow_proxy_cutoff', text='Alpha Cutoff')
             relight_box.operator('sna.dgs_render_build_shadow_proxies_5b787', text='Rebuild Gaussian Shadow Proxies')
     split_A5CFC = box_3D205.split(factor=0.5, align=False)
-    split_A5CFC.alert = False
-    split_A5CFC.enabled = True
-    split_A5CFC.active = True
-    split_A5CFC.use_property_split = False
-    split_A5CFC.use_property_decorate = False
-    split_A5CFC.scale_x = 1.0
-    split_A5CFC.scale_y = 1.0
-    split_A5CFC.alignment = 'Expand'.upper()
-    if not True: split_A5CFC.operator_context = "EXEC_DEFAULT"
     split_A5CFC.label(text='Rig Behaviour', icon_value=0)
     split_A5CFC.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_render_rig_cache_mode', text='', icon_value=0, emboss=True)
     col_A8B0F = box_3D205.column(heading='', align=False)
-    col_A8B0F.alert = False
     col_A8B0F.enabled = ((bpy.context.scene.camera != None) and (bpy.context.scene.render.filepath != '') and (bpy.context.scene.render.image_settings.media_type == 'IMAGE') and (bpy.context.scene.sna_dgs_scene_properties.r2_color or bpy.context.scene.sna_dgs_scene_properties.r2_depth))
-    col_A8B0F.active = True
-    col_A8B0F.use_property_split = False
-    col_A8B0F.use_property_decorate = False
-    col_A8B0F.scale_x = 1.0
     col_A8B0F.scale_y = 2.0
-    col_A8B0F.alignment = 'Expand'.upper()
-    col_A8B0F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     op = col_A8B0F.operator('sna.dgs_render_advanced_render_147af', text='Render', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'camera.svg')), emboss=True, depress=False)
     op = box_3D205.operator('sna.dgs_render_open_output_folder_82000', text='Open Output Folder', icon_value=0, emboss=True, depress=False)
     op.sna_path = os.path.dirname(bpy.context.scene.render.filepath)
     if (bpy.context.scene.camera == None):
         box_3CB16 = box_3D205.box()
-        box_3CB16.alert = False
-        box_3CB16.enabled = True
-        box_3CB16.active = True
-        box_3CB16.use_property_split = False
-        box_3CB16.use_property_decorate = False
-        box_3CB16.alignment = 'Expand'.upper()
-        box_3CB16.scale_x = 1.0
-        box_3CB16.scale_y = 1.0
-        if not True: box_3CB16.operator_context = "EXEC_DEFAULT"
         box_3CB16.label(text='No Active Camera found in Scene', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
     if (bpy.context.scene.render.filepath == ''):
         box_A1F25 = box_3D205.box()
-        box_A1F25.alert = False
-        box_A1F25.enabled = True
-        box_A1F25.active = True
-        box_A1F25.use_property_split = False
-        box_A1F25.use_property_decorate = False
-        box_A1F25.alignment = 'Expand'.upper()
-        box_A1F25.scale_x = 1.0
-        box_A1F25.scale_y = 1.0
-        if not True: box_A1F25.operator_context = "EXEC_DEFAULT"
         box_A1F25.label(text='Output path is empty', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
     if (bpy.context.scene.render.image_settings.media_type == 'IMAGE'):
         pass
     else:
         box_7936D = box_3D205.box()
-        box_7936D.alert = False
-        box_7936D.enabled = True
-        box_7936D.active = True
-        box_7936D.use_property_split = False
-        box_7936D.use_property_decorate = False
-        box_7936D.alignment = 'Expand'.upper()
-        box_7936D.scale_x = 1.0
-        box_7936D.scale_y = 1.0
-        if not True: box_7936D.operator_context = "EXEC_DEFAULT"
         box_7936D.label(text='Set the output Media Type to Image', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
     if (bpy.context.scene.sna_dgs_scene_properties.r2_color or bpy.context.scene.sna_dgs_scene_properties.r2_depth):
         pass
     else:
         box_3B948 = box_3D205.box()
-        box_3B948.alert = False
-        box_3B948.enabled = True
-        box_3B948.active = True
-        box_3B948.use_property_split = False
-        box_3B948.use_property_decorate = False
-        box_3B948.alignment = 'Expand'.upper()
-        box_3B948.scale_x = 1.0
-        box_3B948.scale_y = 1.0
-        if not True: box_3B948.operator_context = "EXEC_DEFAULT"
         box_3B948.label(text='No passes enabled', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))

--- a/src/r2_update_menu.py
+++ b/src/r2_update_menu.py
@@ -33,6 +33,7 @@ def sna_r2_update_menu_6A492(layout_function, ):
     op = col_A95B5.operator('sna.dgs_render_refresh_scene_a6719', text='Update Scene', icon_value=(load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'play.svg')) if (bpy.context.scene.sna_dgs_scene_properties.r2_update_type == 'Interval') else load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'update.svg'))), emboss=True, depress=False)
     if ((bpy.context.scene.sna_dgs_scene_properties.r2_update_type == 'Interval') and (not bpy.context.scene.sna_dgs_scene_properties.r2_interval_stop)):
         col_9AB35 = box_EB86E.column(heading='', align=False)
+        col_9AB35.alert = True
         col_9AB35.scale_y = 2.0
         op = col_9AB35.operator('sna.dgs_render_stop_interval_updates_83370', text='Stop', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'stop.svg')), emboss=True, depress=False)
     if bpy.context.preferences.addons[__package__].preferences.sna_show_tips:

--- a/src/r2_update_menu.py
+++ b/src/r2_update_menu.py
@@ -9,153 +9,39 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_r2_update_menu_6A492(layout_function, ):
     box_EB86E = layout_function.box()
-    box_EB86E.alert = False
-    box_EB86E.enabled = True
-    box_EB86E.active = True
-    box_EB86E.use_property_split = False
-    box_EB86E.use_property_decorate = False
-    box_EB86E.alignment = 'Expand'.upper()
-    box_EB86E.scale_x = 1.0
-    box_EB86E.scale_y = 1.0
-    if not True: box_EB86E.operator_context = "EXEC_DEFAULT"
     box_B1484 = box_EB86E.box()
-    box_B1484.alert = False
-    box_B1484.enabled = True
-    box_B1484.active = True
-    box_B1484.use_property_split = False
-    box_B1484.use_property_decorate = False
-    box_B1484.alignment = 'Expand'.upper()
-    box_B1484.scale_x = 1.0
-    box_B1484.scale_y = 1.0
-    if not True: box_B1484.operator_context = "EXEC_DEFAULT"
     box_B1484.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_hide_on_change', text='Toggle visibility on menu change', icon_value=0, emboss=True)
     box_B1484.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_transforms', text='Copy source transforms', icon_value=0, emboss=True)
     box_B1484.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_selected', text='Update selected Proxy Empties only', icon_value=0, emboss=True)
     row_7FB2A = box_B1484.row(heading='', align=False)
-    row_7FB2A.alert = False
-    row_7FB2A.enabled = True
-    row_7FB2A.active = True
-    row_7FB2A.use_property_split = False
-    row_7FB2A.use_property_decorate = False
-    row_7FB2A.scale_x = 1.0
-    row_7FB2A.scale_y = 1.0
-    row_7FB2A.alignment = 'Expand'.upper()
-    row_7FB2A.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     row_7FB2A.label(text='Rig Behaviour', icon_value=0)
     row_7FB2A.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_render_rig_cache_mode', text='', icon_value=0, emboss=True)
     box_2F177 = box_EB86E.box()
-    box_2F177.alert = False
-    box_2F177.enabled = True
-    box_2F177.active = True
-    box_2F177.use_property_split = False
-    box_2F177.use_property_decorate = False
-    box_2F177.alignment = 'Expand'.upper()
-    box_2F177.scale_x = 1.0
-    box_2F177.scale_y = 1.0
-    if not True: box_2F177.operator_context = "EXEC_DEFAULT"
     col_9BE62 = box_2F177.column(heading='', align=True)
-    col_9BE62.alert = False
-    col_9BE62.enabled = True
-    col_9BE62.active = True
-    col_9BE62.use_property_split = False
-    col_9BE62.use_property_decorate = False
-    col_9BE62.scale_x = 1.0
-    col_9BE62.scale_y = 1.0
-    col_9BE62.alignment = 'Expand'.upper()
-    col_9BE62.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_9BE62.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_sh_degree', text='SH Degrees', icon_value=0, emboss=True, expand=True)
     col_9BE62.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_sort_threshold', text='Camera Move Sort Threshold', icon_value=0, emboss=True, expand=True)
     col_9BE62.prop(bpy.context.scene.sna_dgs_scene_properties, 'rt_rotation_sort_threshold', text='Camera Turn Sort Threshold', icon_value=0, emboss=True, expand=True)
     box_4B521 = box_EB86E.box()
-    box_4B521.alert = False
     box_4B521.enabled = (not ((bpy.context.scene.sna_dgs_scene_properties.r2_update_type == 'Interval') and (not bpy.context.scene.sna_dgs_scene_properties.r2_interval_stop)))
-    box_4B521.active = True
-    box_4B521.use_property_split = False
-    box_4B521.use_property_decorate = False
-    box_4B521.alignment = 'Expand'.upper()
-    box_4B521.scale_x = 1.0
-    box_4B521.scale_y = 1.0
-    if not True: box_4B521.operator_context = "EXEC_DEFAULT"
     col_2B0AE = box_4B521.column(heading='', align=True)
-    col_2B0AE.alert = False
-    col_2B0AE.enabled = True
-    col_2B0AE.active = True
-    col_2B0AE.use_property_split = False
-    col_2B0AE.use_property_decorate = False
-    col_2B0AE.scale_x = 1.0
-    col_2B0AE.scale_y = 1.0
-    col_2B0AE.alignment = 'Expand'.upper()
-    col_2B0AE.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     row_09C1F = col_2B0AE.row(heading='', align=False)
-    row_09C1F.alert = False
-    row_09C1F.enabled = True
-    row_09C1F.active = True
-    row_09C1F.use_property_split = False
-    row_09C1F.use_property_decorate = False
-    row_09C1F.scale_x = 1.0
-    row_09C1F.scale_y = 1.0
-    row_09C1F.alignment = 'Expand'.upper()
-    row_09C1F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     row_09C1F.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_update_type', text=bpy.context.scene.sna_dgs_scene_properties.r2_update_type, icon_value=0, emboss=True, expand=True)
     if (bpy.context.scene.sna_dgs_scene_properties.r2_update_type == 'Interval'):
         col_2B0AE.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_interval', text='Interval Time (Seconds)', icon_value=0, emboss=True, expand=True)
     col_A95B5 = col_2B0AE.column(heading='', align=False)
-    col_A95B5.alert = False
-    col_A95B5.enabled = True
-    col_A95B5.active = True
-    col_A95B5.use_property_split = False
-    col_A95B5.use_property_decorate = False
-    col_A95B5.scale_x = 1.0
     col_A95B5.scale_y = 2.0
-    col_A95B5.alignment = 'Expand'.upper()
-    col_A95B5.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     op = col_A95B5.operator('sna.dgs_render_refresh_scene_a6719', text='Update Scene', icon_value=(load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'play.svg')) if (bpy.context.scene.sna_dgs_scene_properties.r2_update_type == 'Interval') else load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'update.svg'))), emboss=True, depress=False)
     if ((bpy.context.scene.sna_dgs_scene_properties.r2_update_type == 'Interval') and (not bpy.context.scene.sna_dgs_scene_properties.r2_interval_stop)):
         col_9AB35 = box_EB86E.column(heading='', align=False)
-        col_9AB35.alert = True
-        col_9AB35.enabled = True
-        col_9AB35.active = True
-        col_9AB35.use_property_split = False
-        col_9AB35.use_property_decorate = False
-        col_9AB35.scale_x = 1.0
         col_9AB35.scale_y = 2.0
-        col_9AB35.alignment = 'Expand'.upper()
-        col_9AB35.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         op = col_9AB35.operator('sna.dgs_render_stop_interval_updates_83370', text='Stop', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'stop.svg')), emboss=True, depress=False)
     if bpy.context.preferences.addons[__package__].preferences.sna_show_tips:
         col_BE44B = box_EB86E.column(heading='', align=False)
-        col_BE44B.alert = False
-        col_BE44B.enabled = True
-        col_BE44B.active = True
-        col_BE44B.use_property_split = False
-        col_BE44B.use_property_decorate = False
-        col_BE44B.scale_x = 1.0
-        col_BE44B.scale_y = 1.0
-        col_BE44B.alignment = 'Expand'.upper()
-        col_BE44B.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         if (bpy.context.scene.sna_dgs_scene_properties.r2_update_type == 'Interval'):
             box_CCFB1 = col_BE44B.box()
-            box_CCFB1.alert = False
-            box_CCFB1.enabled = True
-            box_CCFB1.active = True
-            box_CCFB1.use_property_split = False
-            box_CCFB1.use_property_decorate = False
-            box_CCFB1.alignment = 'Expand'.upper()
-            box_CCFB1.scale_x = 1.0
-            box_CCFB1.scale_y = 1.0
-            if not True: box_CCFB1.operator_context = "EXEC_DEFAULT"
             box_CCFB1.label(text='Interval Updates are intensive', icon_value=0)
             box_CCFB1.label(text='Use it to preview single, small object animations', icon_value=0)
             box_CCFB1.label(text='Use with caution, expect lagging', icon_value=0)
         box_59076 = col_BE44B.box()
-        box_59076.alert = False
-        box_59076.enabled = True
-        box_59076.active = True
-        box_59076.use_property_split = False
-        box_59076.use_property_decorate = False
-        box_59076.alignment = 'Expand'.upper()
-        box_59076.scale_x = 1.0
-        box_59076.scale_y = 1.0
-        if not True: box_59076.operator_context = "EXEC_DEFAULT"
         box_59076.label(text='If depth sorting fails', icon_value=0)
         box_59076.label(text='Move the camera with Shift+Middle Mouse', icon_value=0)

--- a/src/refresh_create_paint_attribute.py
+++ b/src/refresh_create_paint_attribute.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Refresh__Create_Paint_Attribute_84655(bpy.types.Operator
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         import numpy as np

--- a/src/refresh_scene.py
+++ b/src/refresh_scene.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Refresh_Scene_A6719(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         exec('import os')

--- a/src/remove_by_size.py
+++ b/src/remove_by_size.py
@@ -10,36 +10,10 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_remove_by_size_E1DB7(layout_function, ):
     if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Remove_By Size_GN' in bpy.context.view_layer.objects.active.modifiers):
         box_3DF8E = layout_function.box()
-        box_3DF8E.alert = False
-        box_3DF8E.enabled = True
-        box_3DF8E.active = True
-        box_3DF8E.use_property_split = False
-        box_3DF8E.use_property_decorate = False
-        box_3DF8E.alignment = 'Expand'.upper()
-        box_3DF8E.scale_x = 1.0
-        box_3DF8E.scale_y = 1.0
-        if not True: box_3DF8E.operator_context = "EXEC_DEFAULT"
         split_52769 = box_3DF8E.split(factor=0.5, align=False)
-        split_52769.alert = False
-        split_52769.enabled = True
-        split_52769.active = True
-        split_52769.use_property_split = False
-        split_52769.use_property_decorate = False
-        split_52769.scale_x = 1.0
-        split_52769.scale_y = 1.0
-        split_52769.alignment = 'Expand'.upper()
-        if not True: split_52769.operator_context = "EXEC_DEFAULT"
         split_52769.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Remove_By Size_GN'], 'show_viewport', text='Remove By Size', icon_value=0, emboss=True, toggle=True)
         row_44648 = split_52769.row(heading='', align=True)
-        row_44648.alert = False
-        row_44648.enabled = True
-        row_44648.active = True
-        row_44648.use_property_split = False
-        row_44648.use_property_decorate = False
-        row_44648.scale_x = 1.0
-        row_44648.scale_y = 1.0
         row_44648.alignment = 'Right'.upper()
-        row_44648.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_44648.prop(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Remove_By Size_GN'], 'show_render', text='', icon_value=0, emboss=True, toggle=True)
         op = row_44648.operator('sna.dgs_render_apply_modifier_0f5f2', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'check.svg')), emboss=True, depress=False)
         op.sna_target_object = bpy.context.view_layer.objects.active.name
@@ -48,42 +22,15 @@ def sna_remove_by_size_E1DB7(layout_function, ):
         op.sna_target_object = bpy.context.view_layer.objects.active.name
         op.sna_target_modifier = 'KIRI_3DGS_Remove_By Size_GN'
         col_51C8C = box_3DF8E.column(heading='', align=True)
-        col_51C8C.alert = False
-        col_51C8C.enabled = True
-        col_51C8C.active = True
-        col_51C8C.use_property_split = False
-        col_51C8C.use_property_decorate = False
-        col_51C8C.scale_x = 1.0
-        col_51C8C.scale_y = 1.0
-        col_51C8C.alignment = 'Expand'.upper()
-        col_51C8C.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_8753D = '["' + str('Socket_18' + '"]') 
         col_51C8C.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Remove_By Size_GN'], attr_8753D), text='Remove:', icon_value=0, emboss=True, toggle=True)
         attr_F212A = '["' + str('Socket_5' + '"]') 
         col_51C8C.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Remove_By Size_GN'], attr_F212A), text='Threshold', icon_value=0, emboss=True, toggle=True)
         col_AA341 = box_3DF8E.column(heading='', align=False)
-        col_AA341.alert = False
-        col_AA341.enabled = True
-        col_AA341.active = True
-        col_AA341.use_property_split = False
-        col_AA341.use_property_decorate = False
-        col_AA341.scale_x = 1.0
-        col_AA341.scale_y = 1.0
-        col_AA341.alignment = 'Expand'.upper()
-        col_AA341.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_12417 = '["' + str('Socket_13' + '"]') 
         col_AA341.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Remove_By Size_GN'], attr_12417), text='Remove By Size Masking', icon_value=0, emboss=True, toggle=True)
         if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Remove_By Size_GN']['Socket_13']:
             col_AF706 = col_AA341.column(heading='', align=False)
-            col_AF706.alert = False
-            col_AF706.enabled = True
-            col_AF706.active = True
-            col_AF706.use_property_split = False
-            col_AF706.use_property_decorate = False
-            col_AF706.scale_x = 1.0
-            col_AF706.scale_y = 1.0
-            col_AF706.alignment = 'Expand'.upper()
-            col_AF706.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             attr_952BC = '["' + str('Socket_15' + '"]') 
             col_AF706.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Remove_By Size_GN'], attr_952BC), text='', icon_value=0, emboss=True, toggle=True)
             attr_12EC2 = '["' + str('Socket_14' + '"]') 
@@ -93,25 +40,8 @@ def sna_remove_by_size_E1DB7(layout_function, ):
                 col_AF706.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Remove_By Size_GN'], attr_7198E), text='Distance Threshold', icon_value=0, emboss=True, toggle=True)
     else:
         box_1F29A = layout_function.box()
-        box_1F29A.alert = False
         box_1F29A.enabled = 'OBJECT'==bpy.context.mode
-        box_1F29A.active = True
-        box_1F29A.use_property_split = False
-        box_1F29A.use_property_decorate = False
-        box_1F29A.alignment = 'Expand'.upper()
-        box_1F29A.scale_x = 1.0
-        box_1F29A.scale_y = 1.0
-        if not True: box_1F29A.operator_context = "EXEC_DEFAULT"
         row_8BC2D = box_1F29A.row(heading='', align=False)
-        row_8BC2D.alert = False
-        row_8BC2D.enabled = True
-        row_8BC2D.active = True
-        row_8BC2D.use_property_split = False
-        row_8BC2D.use_property_decorate = False
-        row_8BC2D.scale_x = 1.0
-        row_8BC2D.scale_y = 1.0
-        row_8BC2D.alignment = 'Expand'.upper()
-        row_8BC2D.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_8BC2D.label(text='Remove By Size', icon_value=0)
         op = row_8BC2D.operator('sna.dgs_render_append_geometry_node_modifier_c2492', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'plus-circle.svg')), emboss=True, depress=False)
         op.sna_node_group_name = 'KIRI_3DGS_Remove_By Size_GN'

--- a/src/remove_higher_sh_attributes_86f09.py
+++ b/src/remove_higher_sh_attributes_86f09.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Remove_Higher_Sh_Attributes_86F09(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         TARGET_OBJECT_NAME = bpy.context.view_layer.objects.active.name
@@ -227,15 +227,6 @@ class SNA_OT_Dgs_Render_Remove_Higher_Sh_Attributes_86F09(bpy.types.Operator):
     def draw(self, context):
         layout = self.layout
         box_8FEFB = layout.box()
-        box_8FEFB.alert = False
-        box_8FEFB.enabled = True
-        box_8FEFB.active = True
-        box_8FEFB.use_property_split = False
-        box_8FEFB.use_property_decorate = False
-        box_8FEFB.alignment = 'Expand'.upper()
-        box_8FEFB.scale_x = 1.0
-        box_8FEFB.scale_y = 1.0
-        if not True: box_8FEFB.operator_context = "EXEC_DEFAULT"
         box_8FEFB.label(text='This action is destructive and not reversible', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_8FEFB.label(text='Removing higher SH attributes (f_rest attributes) can save memory and increase performance in some areas.', icon_value=0)
         box_8FEFB.label(text='If you are unsure about what to do, try working on a duplicate.', icon_value=0)

--- a/src/remove_higher_sh_attributes_cb703.py
+++ b/src/remove_higher_sh_attributes_cb703.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Remove_Higher_Sh_Attributes_Cb703(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         TARGET_OBJECT_NAME = bpy.context.view_layer.objects.active.name
@@ -227,15 +227,6 @@ class SNA_OT_Dgs_Render_Remove_Higher_Sh_Attributes_Cb703(bpy.types.Operator):
     def draw(self, context):
         layout = self.layout
         box_DCA59 = layout.box()
-        box_DCA59.alert = False
-        box_DCA59.enabled = True
-        box_DCA59.active = True
-        box_DCA59.use_property_split = False
-        box_DCA59.use_property_decorate = False
-        box_DCA59.alignment = 'Expand'.upper()
-        box_DCA59.scale_x = 1.0
-        box_DCA59.scale_y = 1.0
-        if not True: box_DCA59.operator_context = "EXEC_DEFAULT"
         box_DCA59.label(text='This action is destructive and not reversible', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_DCA59.label(text='Removing higher SH attributes can save memory and increase performance in some areas.', icon_value=0)
         box_DCA59.label(text='If you are unsure about what to do, try working on a duplicate.', icon_value=0)

--- a/src/remove_modifier.py
+++ b/src/remove_modifier.py
@@ -17,9 +17,9 @@ class SNA_OT_Dgs_Render_Remove_Modifier_9Cf0D(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         bpy.data.objects[self.sna_target_object].modifiers.remove(modifier=bpy.data.objects[self.sna_target_object].modifiers[self.sna_target_modifier], )

--- a/src/render_new_menu.py
+++ b/src/render_new_menu.py
@@ -14,24 +14,8 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_render_new_menu_66133(layout_function, ):
     box_D20F4 = layout_function.box()
-    box_D20F4.alert = False
     box_D20F4.enabled = (not ((bpy.context.scene.sna_dgs_scene_properties.r2_update_type == 'Interval Update') and (not bpy.context.scene.sna_dgs_scene_properties.r2_interval_stop)))
-    box_D20F4.active = True
-    box_D20F4.use_property_split = False
-    box_D20F4.use_property_decorate = False
-    box_D20F4.alignment = 'Expand'.upper()
-    box_D20F4.scale_x = 1.0
-    box_D20F4.scale_y = 1.0
-    if not True: box_D20F4.operator_context = "EXEC_DEFAULT"
     grid_DDB98 = box_D20F4.grid_flow(columns=2, row_major=False, even_columns=False, even_rows=False, align=True)
-    grid_DDB98.enabled = True
-    grid_DDB98.active = True
-    grid_DDB98.use_property_split = False
-    grid_DDB98.use_property_decorate = False
-    grid_DDB98.alignment = 'Expand'.upper()
-    grid_DDB98.scale_x = 1.0
-    grid_DDB98.scale_y = 1.0
-    if not True: grid_DDB98.operator_context = "EXEC_DEFAULT"
     grid_DDB98.prop(bpy.context.scene.sna_dgs_scene_properties, 'r2_main_mode', text=bpy.context.scene.sna_dgs_scene_properties.r2_main_mode, icon_value=0, emboss=True, expand=True)
     if bpy.context.scene.sna_dgs_scene_properties.r2_main_mode == "Update":
         layout_function = layout_function
@@ -49,25 +33,7 @@ def sna_render_new_menu_66133(layout_function, ):
         pass
     if (property_exists("bpy.context.view_layer.objects.active.modifiers", globals(), locals()) and 'KIRI_3DGS_Adjust_Attributes_GN' in bpy.context.view_layer.objects.active.modifiers):
         col_5A5DB = layout_function.column(heading='', align=False)
-        col_5A5DB.alert = False
-        col_5A5DB.enabled = True
-        col_5A5DB.active = True
-        col_5A5DB.use_property_split = False
-        col_5A5DB.use_property_decorate = False
-        col_5A5DB.scale_x = 1.0
-        col_5A5DB.scale_y = 1.0
-        col_5A5DB.alignment = 'Expand'.upper()
-        col_5A5DB.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         box_83499 = col_5A5DB.box()
-        box_83499.alert = False
-        box_83499.enabled = True
-        box_83499.active = True
-        box_83499.use_property_split = False
-        box_83499.use_property_decorate = False
-        box_83499.alignment = 'Expand'.upper()
-        box_83499.scale_x = 1.0
-        box_83499.scale_y = 1.0
-        if not True: box_83499.operator_context = "EXEC_DEFAULT"
         box_83499.label(text='Active Object: ' + bpy.context.view_layer.objects.active.name, icon_value=0)
         layout_function = col_5A5DB
         sna_attribute_adjust_properties_2C323(layout_function, )

--- a/src/restore_original_light.py
+++ b/src/restore_original_light.py
@@ -17,9 +17,9 @@ class SNA_OT_Dgs_Render_Restore_Original_Light_9A7Fe(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         sna_relight2_4_restore_original_3dgs_color_08334()

--- a/src/rig.py
+++ b/src/rig.py
@@ -40,6 +40,7 @@ def sna_rig_891FC(layout_function, ):
                     if 'proxy_binding_active' in bpy.context.view_layer.objects.active:
                         if bpy.context.view_layer.objects.active['proxy_binding_active']:
                             box_B68AA = col_29EE2.box()
+                            box_B68AA.alert = True
                             op = box_B68AA.operator('sna.dgs_render_unbind_from_proxy_mesh_7648d', text='Unbind', icon_value=0, emboss=True, depress=False)
                         else:
                             box_485E0 = col_29EE2.box()
@@ -131,6 +132,7 @@ def sna_rig_891FC(layout_function, ):
                                                 op = col_16CA7.operator('sna.dgs_render_update_bound_3dgs_from_cache_385ec', text='Update from cache', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'play.svg')), emboss=True, depress=False)
                                             else:
                                                 col_BE41C = col_16CA7.column(heading='', align=False)
+                                                col_BE41C.alert = True
                                                 op = col_BE41C.operator('sna.dgs_render_end_proxy_rig_updates_60c6a', text='Stop', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'stop.svg')), emboss=True, depress=False)
                                 else:
                                     pass

--- a/src/rig.py
+++ b/src/rig.py
@@ -13,52 +13,18 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_rig_891FC(layout_function, ):
     if (bpy.context.preferences.addons[__package__].preferences.sna_cache_file_directory == ''):
         box_B8623 = layout_function.box()
-        box_B8623.alert = False
-        box_B8623.enabled = True
-        box_B8623.active = True
-        box_B8623.use_property_split = False
-        box_B8623.use_property_decorate = False
-        box_B8623.alignment = 'Expand'.upper()
-        box_B8623.scale_x = 1.0
-        box_B8623.scale_y = 1.0
-        if not True: box_B8623.operator_context = "EXEC_DEFAULT"
         box_B8623.label(text='Cache directory is empty.', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_B8623.label(text='Set it in Preferences', icon_value=0)
     col_939A0 = layout_function.column(heading='', align=True)
-    col_939A0.alert = False
     col_939A0.enabled = (bpy.context.preferences.addons[__package__].preferences.sna_cache_file_directory != '')
-    col_939A0.active = True
-    col_939A0.use_property_split = False
-    col_939A0.use_property_decorate = False
-    col_939A0.scale_x = 1.0
-    col_939A0.scale_y = 1.0
-    col_939A0.alignment = 'Expand'.upper()
-    col_939A0.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_939A0.label(text='Binding Data', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
     if (bpy.context.view_layer.objects.active == None):
         box_D50A3 = col_939A0.box()
-        box_D50A3.alert = False
-        box_D50A3.enabled = True
-        box_D50A3.active = True
-        box_D50A3.use_property_split = False
-        box_D50A3.use_property_decorate = False
-        box_D50A3.alignment = 'Expand'.upper()
-        box_D50A3.scale_x = 1.0
         box_D50A3.scale_y = 2.0
-        if not True: box_D50A3.operator_context = "EXEC_DEFAULT"
         box_D50A3.label(text='No Active Object', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
     else:
         if bpy.context.view_layer.objects.active.type == 'ARMATURE':
             box_C4E6D = col_939A0.box()
-            box_C4E6D.alert = False
-            box_C4E6D.enabled = True
-            box_C4E6D.active = True
-            box_C4E6D.use_property_split = False
-            box_C4E6D.use_property_decorate = False
-            box_C4E6D.alignment = 'Expand'.upper()
-            box_C4E6D.scale_x = 1.0
-            box_C4E6D.scale_y = 1.0
-            if not True: box_C4E6D.operator_context = "EXEC_DEFAULT"
             box_C4E6D.label(text='Armature Tools', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
             box_C4E6D.prop(bpy.context.view_layer.objects.active.data, 'pose_position', text=bpy.context.view_layer.objects.active.data.pose_position, icon_value=0, emboss=True, expand=True)
             op = box_C4E6D.operator('sna.dgs_render_apply_armature_pose_as_rest_pose_a8c68', text='Apply pose as Rest Pose', icon_value=0, emboss=True, depress=False)
@@ -66,89 +32,26 @@ def sna_rig_891FC(layout_function, ):
             if '3DGS_Mesh_Type' in bpy.context.view_layer.objects.active:
                 if (bpy.context.view_layer.objects.active['3DGS_Mesh_Type'] == 'face'):
                     box_A082B = col_939A0.box()
-                    box_A082B.alert = False
-                    box_A082B.enabled = True
-                    box_A082B.active = True
-                    box_A082B.use_property_split = False
-                    box_A082B.use_property_decorate = False
-                    box_A082B.alignment = 'Expand'.upper()
-                    box_A082B.scale_x = 1.0
-                    box_A082B.scale_y = 1.0
-                    if not True: box_A082B.operator_context = "EXEC_DEFAULT"
                     box_A082B.label(text='Rigging is only available for Vert based', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
                     box_A082B.label(text='3DGS objects. You can convert this object', icon_value=0)
                     box_A082B.label(text='from the Ctrl+A menu', icon_value=0)
                 else:
                     col_29EE2 = col_939A0.column(heading='', align=False)
-                    col_29EE2.alert = False
-                    col_29EE2.enabled = True
-                    col_29EE2.active = True
-                    col_29EE2.use_property_split = False
-                    col_29EE2.use_property_decorate = False
-                    col_29EE2.scale_x = 1.0
-                    col_29EE2.scale_y = 1.0
-                    col_29EE2.alignment = 'Expand'.upper()
-                    col_29EE2.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                     if 'proxy_binding_active' in bpy.context.view_layer.objects.active:
                         if bpy.context.view_layer.objects.active['proxy_binding_active']:
                             box_B68AA = col_29EE2.box()
-                            box_B68AA.alert = True
-                            box_B68AA.enabled = True
-                            box_B68AA.active = True
-                            box_B68AA.use_property_split = False
-                            box_B68AA.use_property_decorate = False
-                            box_B68AA.alignment = 'Expand'.upper()
-                            box_B68AA.scale_x = 1.0
-                            box_B68AA.scale_y = 1.0
-                            if not True: box_B68AA.operator_context = "EXEC_DEFAULT"
                             op = box_B68AA.operator('sna.dgs_render_unbind_from_proxy_mesh_7648d', text='Unbind', icon_value=0, emboss=True, depress=False)
                         else:
                             box_485E0 = col_29EE2.box()
-                            box_485E0.alert = False
-                            box_485E0.enabled = True
-                            box_485E0.active = True
-                            box_485E0.use_property_split = False
-                            box_485E0.use_property_decorate = False
-                            box_485E0.alignment = 'Expand'.upper()
-                            box_485E0.scale_x = 1.0
-                            box_485E0.scale_y = 1.0
-                            if not True: box_485E0.operator_context = "EXEC_DEFAULT"
                             op = box_485E0.operator('sna.dgs_render_unbind_from_proxy_mesh_7648d', text='Unbind / Refresh', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'refresh.svg')), emboss=True, depress=False)
                     box_B63D8 = col_29EE2.box()
-                    box_B63D8.alert = False
-                    box_B63D8.enabled = True
-                    box_B63D8.active = True
-                    box_B63D8.use_property_split = False
-                    box_B63D8.use_property_decorate = False
-                    box_B63D8.alignment = 'Expand'.upper()
-                    box_B63D8.scale_x = 1.0
-                    box_B63D8.scale_y = 1.0
-                    if not True: box_B63D8.operator_context = "EXEC_DEFAULT"
                     box_B63D8.label(text='Proxy Mesh', icon_value=0)
                     row_6ADB2 = box_B63D8.row(heading='', align=True)
-                    row_6ADB2.alert = False
-                    row_6ADB2.enabled = True
-                    row_6ADB2.active = True
-                    row_6ADB2.use_property_split = False
-                    row_6ADB2.use_property_decorate = False
-                    row_6ADB2.scale_x = 1.0
-                    row_6ADB2.scale_y = 1.0
-                    row_6ADB2.alignment = 'Expand'.upper()
-                    row_6ADB2.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                     row_6ADB2.prop(bpy.context.view_layer.objects.active.sna_dgs_object_properties, 'rig_proxy_mesh', text='', icon_value=0, emboss=True)
                     if (bpy.context.view_layer.objects.active.sna_dgs_object_properties.rig_proxy_mesh == None):
                         pass
                     else:
                         row_E7B4F = row_6ADB2.row(heading='', align=True)
-                        row_E7B4F.alert = False
-                        row_E7B4F.enabled = True
-                        row_E7B4F.active = True
-                        row_E7B4F.use_property_split = False
-                        row_E7B4F.use_property_decorate = False
-                        row_E7B4F.scale_x = 1.0
-                        row_E7B4F.scale_y = 1.0
-                        row_E7B4F.alignment = 'Expand'.upper()
-                        row_E7B4F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                         op = row_E7B4F.operator('sna.dgs_render_select_object_b1f49', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'mouse-pointer.svg')), emboss=True, depress=False)
                         op.sna_object_name = bpy.context.view_layer.objects.active.sna_dgs_object_properties.rig_proxy_mesh.name
                         row_E7B4F.prop(bpy.context.view_layer.objects.active.sna_dgs_object_properties.rig_proxy_mesh, 'hide_viewport', text='', icon_value=0, emboss=True)
@@ -160,59 +63,14 @@ def sna_rig_891FC(layout_function, ):
                         if 'proxy_binding_active' in bpy.context.view_layer.objects.active:
                             if bpy.context.view_layer.objects.active['proxy_binding_active']:
                                 col_73DBB = col_29EE2.column(heading='', align=False)
-                                col_73DBB.alert = False
-                                col_73DBB.enabled = True
-                                col_73DBB.active = True
-                                col_73DBB.use_property_split = False
-                                col_73DBB.use_property_decorate = False
-                                col_73DBB.scale_x = 1.0
-                                col_73DBB.scale_y = 1.0
-                                col_73DBB.alignment = 'Expand'.upper()
-                                col_73DBB.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                                 box_21FC2 = col_73DBB.box()
-                                box_21FC2.alert = False
-                                box_21FC2.enabled = True
-                                box_21FC2.active = True
-                                box_21FC2.use_property_split = False
-                                box_21FC2.use_property_decorate = False
-                                box_21FC2.alignment = 'Expand'.upper()
-                                box_21FC2.scale_x = 1.0
-                                box_21FC2.scale_y = 1.0
-                                if not True: box_21FC2.operator_context = "EXEC_DEFAULT"
                                 box_21FC2.label(text='Update Settings', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
                                 col_4847A = box_21FC2.column(heading='', align=True)
-                                col_4847A.alert = False
-                                col_4847A.enabled = True
-                                col_4847A.active = True
-                                col_4847A.use_property_split = False
-                                col_4847A.use_property_decorate = False
-                                col_4847A.scale_x = 1.0
-                                col_4847A.scale_y = 1.0
-                                col_4847A.alignment = 'Expand'.upper()
-                                col_4847A.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                                 col_4847A.label(text='Update Mode', icon_value=0)
                                 row_88338 = col_4847A.row(heading='', align=False)
-                                row_88338.alert = False
-                                row_88338.enabled = True
-                                row_88338.active = True
-                                row_88338.use_property_split = False
-                                row_88338.use_property_decorate = False
-                                row_88338.scale_x = 1.0
-                                row_88338.scale_y = 1.0
-                                row_88338.alignment = 'Expand'.upper()
-                                row_88338.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                                 row_88338.prop(bpy.context.scene.sna_dgs_scene_properties, 'rig_update_mode', text=bpy.context.scene.sna_dgs_scene_properties.rig_update_mode, icon_value=0, emboss=True, expand=True)
                                 if bpy.context.scene.sna_dgs_scene_properties.rig_update_mode == "Single":
                                     col_2CAD4 = box_21FC2.column(heading='', align=False)
-                                    col_2CAD4.alert = False
-                                    col_2CAD4.enabled = True
-                                    col_2CAD4.active = True
-                                    col_2CAD4.use_property_split = False
-                                    col_2CAD4.use_property_decorate = False
-                                    col_2CAD4.scale_x = 1.0
-                                    col_2CAD4.scale_y = 1.0
-                                    col_2CAD4.alignment = 'Expand'.upper()
-                                    col_2CAD4.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                                     if 'proxy_sequence_binding' in bpy.context.view_layer.objects.active:
                                         if bpy.context.view_layer.objects.active['proxy_sequence_binding']:
                                             layout_function = col_2CAD4
@@ -225,27 +83,10 @@ def sna_rig_891FC(layout_function, ):
                                         sna_rig_update_settings_88DF0(layout_function, False, True)
                                     col_2CAD4.separator(factor=1.0)
                                     col_DF573 = col_2CAD4.column(heading='', align=False)
-                                    col_DF573.alert = False
-                                    col_DF573.enabled = True
-                                    col_DF573.active = True
-                                    col_DF573.use_property_split = False
-                                    col_DF573.use_property_decorate = False
-                                    col_DF573.scale_x = 1.0
                                     col_DF573.scale_y = 2.0
-                                    col_DF573.alignment = 'Expand'.upper()
-                                    col_DF573.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                                     op = col_DF573.operator('sna.dgs_render_update_bound_3dgs_from_proxy_mesh_951a0', text='Update Single', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'update.svg')), emboss=True, depress=False)
                                 elif bpy.context.scene.sna_dgs_scene_properties.rig_update_mode == "Interval":
                                     col_6A648 = box_21FC2.column(heading='', align=False)
-                                    col_6A648.alert = False
-                                    col_6A648.enabled = True
-                                    col_6A648.active = True
-                                    col_6A648.use_property_split = False
-                                    col_6A648.use_property_decorate = False
-                                    col_6A648.scale_x = 1.0
-                                    col_6A648.scale_y = 1.0
-                                    col_6A648.alignment = 'Expand'.upper()
-                                    col_6A648.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                                     if 'proxy_sequence_binding' in bpy.context.view_layer.objects.active:
                                         if bpy.context.view_layer.objects.active['proxy_sequence_binding']:
                                             layout_function = col_6A648
@@ -258,15 +99,6 @@ def sna_rig_891FC(layout_function, ):
                                         sna_rig_update_settings_88DF0(layout_function, False, True)
                                     col_6A648.separator(factor=1.0)
                                     box_3F9E9 = col_6A648.box()
-                                    box_3F9E9.alert = False
-                                    box_3F9E9.enabled = True
-                                    box_3F9E9.active = True
-                                    box_3F9E9.use_property_split = False
-                                    box_3F9E9.use_property_decorate = False
-                                    box_3F9E9.alignment = 'Expand'.upper()
-                                    box_3F9E9.scale_x = 1.0
-                                    box_3F9E9.scale_y = 1.0
-                                    if not True: box_3F9E9.operator_context = "EXEC_DEFAULT"
                                     if 'proxy_sequence_binding' in bpy.context.view_layer.objects.active:
                                         if bpy.context.view_layer.objects.active['proxy_sequence_binding']:
                                             layout_function = box_3F9E9
@@ -282,74 +114,23 @@ def sna_rig_891FC(layout_function, ):
                                             pass
                                         else:
                                             col_55551 = box_3F9E9.column(heading='', align=False)
-                                            col_55551.alert = False
-                                            col_55551.enabled = True
-                                            col_55551.active = True
-                                            col_55551.use_property_split = False
-                                            col_55551.use_property_decorate = False
-                                            col_55551.scale_x = 1.0
                                             col_55551.scale_y = 2.0
-                                            col_55551.alignment = 'Expand'.upper()
-                                            col_55551.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                                             op = col_55551.operator('sna.dgs_render_bake_frames_to_cache_90885', text='Bake Frames to Cache', icon_value=0, emboss=True, depress=False)
                                     else:
                                         col_A92B7 = box_3F9E9.column(heading='', align=False)
-                                        col_A92B7.alert = False
-                                        col_A92B7.enabled = True
-                                        col_A92B7.active = True
-                                        col_A92B7.use_property_split = False
-                                        col_A92B7.use_property_decorate = False
-                                        col_A92B7.scale_x = 1.0
                                         col_A92B7.scale_y = 2.0
-                                        col_A92B7.alignment = 'Expand'.upper()
-                                        col_A92B7.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                                         op = col_A92B7.operator('sna.dgs_render_bake_frames_to_cache_90885', text='Bake Frames to Cache', icon_value=0, emboss=True, depress=False)
                                     if 'proxy_sequence_binding' in bpy.context.view_layer.objects.active:
                                         if bpy.context.view_layer.objects.active['proxy_sequence_binding']:
                                             box_0905C = col_6A648.box()
-                                            box_0905C.alert = False
-                                            box_0905C.enabled = True
-                                            box_0905C.active = True
-                                            box_0905C.use_property_split = False
-                                            box_0905C.use_property_decorate = False
-                                            box_0905C.alignment = 'Expand'.upper()
-                                            box_0905C.scale_x = 1.0
-                                            box_0905C.scale_y = 1.0
-                                            if not True: box_0905C.operator_context = "EXEC_DEFAULT"
                                             col_935FA = box_0905C.column(heading='', align=True)
-                                            col_935FA.alert = False
-                                            col_935FA.enabled = True
-                                            col_935FA.active = True
-                                            col_935FA.use_property_split = False
-                                            col_935FA.use_property_decorate = False
-                                            col_935FA.scale_x = 1.0
-                                            col_935FA.scale_y = 1.0
-                                            col_935FA.alignment = 'Expand'.upper()
-                                            col_935FA.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                                             col_935FA.prop(bpy.context.scene.sna_dgs_scene_properties, 'rig_update_interval', text='Update Interval', icon_value=0, emboss=True)
                                             col_16CA7 = col_935FA.column(heading='', align=False)
-                                            col_16CA7.alert = False
-                                            col_16CA7.enabled = True
-                                            col_16CA7.active = True
-                                            col_16CA7.use_property_split = False
-                                            col_16CA7.use_property_decorate = False
-                                            col_16CA7.scale_x = 1.0
                                             col_16CA7.scale_y = 2.0
-                                            col_16CA7.alignment = 'Expand'.upper()
-                                            col_16CA7.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                                             if bpy.context.scene.sna_dgs_scene_properties.rig_interval_stop:
                                                 op = col_16CA7.operator('sna.dgs_render_update_bound_3dgs_from_cache_385ec', text='Update from cache', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'play.svg')), emboss=True, depress=False)
                                             else:
                                                 col_BE41C = col_16CA7.column(heading='', align=False)
-                                                col_BE41C.alert = True
-                                                col_BE41C.enabled = True
-                                                col_BE41C.active = True
-                                                col_BE41C.use_property_split = False
-                                                col_BE41C.use_property_decorate = False
-                                                col_BE41C.scale_x = 1.0
-                                                col_BE41C.scale_y = 1.0
-                                                col_BE41C.alignment = 'Expand'.upper()
-                                                col_BE41C.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                                                 op = col_BE41C.operator('sna.dgs_render_end_proxy_rig_updates_60c6a', text='Stop', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'stop.svg')), emboss=True, depress=False)
                                 else:
                                     pass
@@ -358,15 +139,6 @@ def sna_rig_891FC(layout_function, ):
                                     if bpy.context.view_layer.objects.active['proxy_sequence_binding']:
                                         if 'rig_baked_render_enabled' in bpy.context.view_layer.objects.active:
                                             box_0F4AD = col_73DBB.box()
-                                            box_0F4AD.alert = False
-                                            box_0F4AD.enabled = True
-                                            box_0F4AD.active = True
-                                            box_0F4AD.use_property_split = False
-                                            box_0F4AD.use_property_decorate = False
-                                            box_0F4AD.alignment = 'Expand'.upper()
-                                            box_0F4AD.scale_x = 1.0
-                                            box_0F4AD.scale_y = 1.0
-                                            if not True: box_0F4AD.operator_context = "EXEC_DEFAULT"
                                             box_0F4AD.label(text='Rig Render Settings', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
                                             attr_003BE = '["' + str('rig_baked_render_enabled' + '"]') 
                                             box_0F4AD.prop(bpy.context.view_layer.objects.active, attr_003BE, text='Enable rig updates in renders', icon_value=0, emboss=True)
@@ -381,13 +153,5 @@ def sna_rig_891FC(layout_function, ):
                             sna_bind_and_misc_tools_C36C1(layout_function, )
             else:
                 box_958E5 = col_939A0.box()
-                box_958E5.alert = False
-                box_958E5.enabled = True
-                box_958E5.active = True
-                box_958E5.use_property_split = False
-                box_958E5.use_property_decorate = False
-                box_958E5.alignment = 'Expand'.upper()
-                box_958E5.scale_x = 1.0
                 box_958E5.scale_y = 2.0
-                if not True: box_958E5.operator_context = "EXEC_DEFAULT"
                 box_958E5.label(text='The Active Object is not a 3DGS Mesh', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))

--- a/src/rig_cache_frames.py
+++ b/src/rig_cache_frames.py
@@ -9,15 +9,7 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_rig_cache_frames_993DF(layout_function, enabled):
     col_EF5B6 = layout_function.column(heading='', align=True)
-    col_EF5B6.alert = False
     col_EF5B6.enabled = enabled
-    col_EF5B6.active = True
-    col_EF5B6.use_property_split = False
-    col_EF5B6.use_property_decorate = False
-    col_EF5B6.scale_x = 1.0
-    col_EF5B6.scale_y = 1.0
-    col_EF5B6.alignment = 'Expand'.upper()
-    col_EF5B6.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_EF5B6.prop(bpy.context.scene.sna_dgs_scene_properties, 'rig_bake_start_frame', text='Start Frame', icon_value=0, emboss=True)
     col_EF5B6.prop(bpy.context.scene.sna_dgs_scene_properties, 'rig_bake_end_frame', text='End Frame', icon_value=0, emboss=True)
     col_EF5B6.prop(bpy.context.scene.sna_dgs_scene_properties, 'rig_bake_frame_step', text='Frame Step', icon_value=0, emboss=True)

--- a/src/rig_update_settings.py
+++ b/src/rig_update_settings.py
@@ -11,72 +11,26 @@ def sna_rig_update_settings_88DF0(layout_function, alert, enabled):
     if 'proxy_sequence_binding' in bpy.context.view_layer.objects.active:
         if bpy.context.view_layer.objects.active['proxy_sequence_binding']:
             box_3ABA6 = layout_function.box()
-            box_3ABA6.alert = True
-            box_3ABA6.enabled = True
-            box_3ABA6.active = True
-            box_3ABA6.use_property_split = False
-            box_3ABA6.use_property_decorate = False
-            box_3ABA6.alignment = 'Expand'.upper()
-            box_3ABA6.scale_x = 1.0
-            box_3ABA6.scale_y = 1.0
-            if not True: box_3ABA6.operator_context = "EXEC_DEFAULT"
             box_3ABA6.label(text='Active Object has baked data', icon_value=load_preview_icon(''))
             op = box_3ABA6.operator('sna.dgs_render_clear_rig_cache_f38be', text='Clear Cache', icon_value=0, emboss=True, depress=False)
     col_8A21A = layout_function.column(heading='', align=True)
     col_8A21A.alert = alert
     col_8A21A.enabled = enabled
-    col_8A21A.active = True
-    col_8A21A.use_property_split = False
-    col_8A21A.use_property_decorate = False
-    col_8A21A.scale_x = 1.0
-    col_8A21A.scale_y = 1.0
-    col_8A21A.alignment = 'Expand'.upper()
-    col_8A21A.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_8A21A.label(text='Deform Mode', icon_value=0)
     col_8A21A.prop(bpy.context.scene.sna_dgs_scene_properties, 'rig_deform_mode', text='', icon_value=0, emboss=True)
     col_384C8 = layout_function.column(heading='', align=True)
     col_384C8.alert = alert
     col_384C8.enabled = enabled
-    col_384C8.active = True
-    col_384C8.use_property_split = False
-    col_384C8.use_property_decorate = False
-    col_384C8.scale_x = 1.0
-    col_384C8.scale_y = 1.0
-    col_384C8.alignment = 'Expand'.upper()
-    col_384C8.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_384C8.label(text='Scale Adjust Mode', icon_value=0)
     col_384C8.prop(bpy.context.scene.sna_dgs_scene_properties, 'rig_scale_safety_mode', text='', icon_value=0, emboss=True)
     col_96F9F = layout_function.column(heading='', align=True)
     col_96F9F.alert = alert
     col_96F9F.enabled = enabled
-    col_96F9F.active = True
-    col_96F9F.use_property_split = False
-    col_96F9F.use_property_decorate = False
-    col_96F9F.scale_x = 1.0
-    col_96F9F.scale_y = 1.0
-    col_96F9F.alignment = 'Expand'.upper()
-    col_96F9F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_96F9F.prop(bpy.context.scene.sna_dgs_scene_properties, 'rig_update_sh_attributes', text='Update Spherical Harmonics', icon_value=0, emboss=True)
     if bpy.context.scene.sna_dgs_scene_properties.rig_update_sh_attributes:
         col_FEC76 = col_96F9F.column(heading='', align=True)
         col_FEC76.alert = alert
         col_FEC76.enabled = enabled
-        col_FEC76.active = True
-        col_FEC76.use_property_split = False
-        col_FEC76.use_property_decorate = False
-        col_FEC76.scale_x = 1.0
-        col_FEC76.scale_y = 1.0
-        col_FEC76.alignment = 'Expand'.upper()
-        col_FEC76.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         col_FEC76.label(text='SH Quality', icon_value=0)
         row_83260 = col_FEC76.row(heading='', align=False)
-        row_83260.alert = False
-        row_83260.enabled = True
-        row_83260.active = True
-        row_83260.use_property_split = False
-        row_83260.use_property_decorate = False
-        row_83260.scale_x = 1.0
-        row_83260.scale_y = 1.0
-        row_83260.alignment = 'Expand'.upper()
-        row_83260.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         row_83260.prop(bpy.context.scene.sna_dgs_scene_properties, 'rig_sh_quality_mode', text=bpy.context.scene.sna_dgs_scene_properties.rig_sh_quality_mode, icon_value=0, emboss=True, expand=True)

--- a/src/rig_update_settings.py
+++ b/src/rig_update_settings.py
@@ -11,6 +11,7 @@ def sna_rig_update_settings_88DF0(layout_function, alert, enabled):
     if 'proxy_sequence_binding' in bpy.context.view_layer.objects.active:
         if bpy.context.view_layer.objects.active['proxy_sequence_binding']:
             box_3ABA6 = layout_function.box()
+            box_3ABA6.alert = True
             box_3ABA6.label(text='Active Object has baked data', icon_value=load_preview_icon(''))
             op = box_3ABA6.operator('sna.dgs_render_clear_rig_cache_f38be', text='Clear Cache', icon_value=0, emboss=True, depress=False)
     col_8A21A = layout_function.column(heading='', align=True)

--- a/src/rotate_for_blender_axes.py
+++ b/src/rotate_for_blender_axes.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Rotate_For_Blender_Axes_423De(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         bpy.context.view_layer.objects.active.rotation_euler = (math.radians(-90.0), math.radians(0.0), math.radians(-90.0))

--- a/src/select_by_object.py
+++ b/src/select_by_object.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Select_By_Object_92F9C(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         SELECTION_OBJ = bpy.context.scene.sna_dgs_scene_properties.select_select_by_obj

--- a/src/select_object.py
+++ b/src/select_object.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Select_Object_B1F49(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         input_object = bpy.data.objects[self.sna_object_name]

--- a/src/select_proxy_mesh.py
+++ b/src/select_proxy_mesh.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Select_Proxy_Mesh_E76B7(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         input_object = bpy.context.view_layer.objects.active.sna_dgs_object_properties.rig_proxy_mesh

--- a/src/selective_adjustment_1_function_interface.py
+++ b/src/selective_adjustment_1_function_interface.py
@@ -10,40 +10,14 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_selective_adjustment_1_function_interface_AD57C(layout_function, ):
     col_8C182 = layout_function.column(heading='', align=False)
-    col_8C182.alert = False
-    col_8C182.enabled = True
-    col_8C182.active = True
-    col_8C182.use_property_split = False
-    col_8C182.use_property_decorate = False
-    col_8C182.scale_x = 1.0
-    col_8C182.scale_y = 1.0
-    col_8C182.alignment = 'Expand'.upper()
-    col_8C182.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_8C182.label(text='Selective Adjustment 1', icon_value=0)
     col_8C182.separator(factor=1.0)
     attr_8071F = '["' + str('Socket_10' + '"]') 
     col_8C182.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_8071F), text='Enable Selective Colour 1', icon_value=0, emboss=True, toggle=True)
     col_8C182.separator(factor=1.0)
     col_B3736 = col_8C182.column(heading='', align=False)
-    col_B3736.alert = False
     col_B3736.enabled = bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_10']
-    col_B3736.active = True
-    col_B3736.use_property_split = False
-    col_B3736.use_property_decorate = False
-    col_B3736.scale_x = 1.0
-    col_B3736.scale_y = 1.0
-    col_B3736.alignment = 'Expand'.upper()
-    col_B3736.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     box_98D42 = col_B3736.box()
-    box_98D42.alert = False
-    box_98D42.enabled = True
-    box_98D42.active = True
-    box_98D42.use_property_split = False
-    box_98D42.use_property_decorate = False
-    box_98D42.alignment = 'Expand'.upper()
-    box_98D42.scale_x = 1.0
-    box_98D42.scale_y = 1.0
-    if not True: box_98D42.operator_context = "EXEC_DEFAULT"
     box_98D42.label(text='Selection Type', icon_value=0)
     attr_8D909 = '["' + str('Socket_24' + '"]') 
     box_98D42.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_8D909), text='', icon_value=0, emboss=True)
@@ -58,15 +32,6 @@ def sna_selective_adjustment_1_function_interface_AD57C(layout_function, ):
     attr_0164F = '["' + str('Socket_28' + '"]') 
     box_98D42.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_0164F), text='Value Threshold', icon_value=0, emboss=True)
     box_067A3 = col_B3736.box()
-    box_067A3.alert = False
-    box_067A3.enabled = True
-    box_067A3.active = True
-    box_067A3.use_property_split = False
-    box_067A3.use_property_decorate = False
-    box_067A3.alignment = 'Expand'.upper()
-    box_067A3.scale_x = 1.0
-    box_067A3.scale_y = 1.0
-    if not True: box_067A3.operator_context = "EXEC_DEFAULT"
     box_067A3.label(text='Blend Mode', icon_value=0)
     attr_F9F7E = '["' + str('Socket_31' + '"]') 
     box_067A3.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_F9F7E), text='', icon_value=0, emboss=True)
@@ -76,28 +41,11 @@ def sna_selective_adjustment_1_function_interface_AD57C(layout_function, ):
     box_067A3.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_BFCE5), text='Randomise Mix', icon_value=0, emboss=True)
     box_3ED76 = col_B3736.box()
     box_3ED76.alert = bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_33']
-    box_3ED76.enabled = True
-    box_3ED76.active = True
-    box_3ED76.use_property_split = False
-    box_3ED76.use_property_decorate = False
-    box_3ED76.alignment = 'Expand'.upper()
-    box_3ED76.scale_x = 1.0
-    box_3ED76.scale_y = 1.0
-    if not True: box_3ED76.operator_context = "EXEC_DEFAULT"
     box_3ED76.label(text='Masking', icon_value=0)
     attr_74E93 = '["' + str('Socket_33' + '"]') 
     box_3ED76.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_74E93), text='Mask By Object', icon_value=0, emboss=True, toggle=True)
     if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_33']:
         col_29C70 = box_3ED76.column(heading='', align=False)
-        col_29C70.alert = False
-        col_29C70.enabled = True
-        col_29C70.active = True
-        col_29C70.use_property_split = False
-        col_29C70.use_property_decorate = False
-        col_29C70.scale_x = 1.0
-        col_29C70.scale_y = 1.0
-        col_29C70.alignment = 'Expand'.upper()
-        col_29C70.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_6C86C = '["' + str('Socket_35' + '"]') 
         col_29C70.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_6C86C), text='', icon_value=0, emboss=True, toggle=True)
         attr_1D6B4 = '["' + str('Socket_34' + '"]') 

--- a/src/selective_adjustment_2_function_interface.py
+++ b/src/selective_adjustment_2_function_interface.py
@@ -10,40 +10,14 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_selective_adjustment_2_function_interface_4A09B(layout_function, ):
     col_3234F = layout_function.column(heading='', align=False)
-    col_3234F.alert = False
-    col_3234F.enabled = True
-    col_3234F.active = True
-    col_3234F.use_property_split = False
-    col_3234F.use_property_decorate = False
-    col_3234F.scale_x = 1.0
-    col_3234F.scale_y = 1.0
-    col_3234F.alignment = 'Expand'.upper()
-    col_3234F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_3234F.label(text='Selective Adjustment 2', icon_value=0)
     col_3234F.separator(factor=1.0)
     attr_8064D = '["' + str('Socket_16' + '"]') 
     col_3234F.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_8064D), text='Enable Selective Colour 2', icon_value=0, emboss=True, toggle=True)
     col_3234F.separator(factor=1.0)
     col_1ACBE = col_3234F.column(heading='', align=False)
-    col_1ACBE.alert = False
     col_1ACBE.enabled = bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_16']
-    col_1ACBE.active = True
-    col_1ACBE.use_property_split = False
-    col_1ACBE.use_property_decorate = False
-    col_1ACBE.scale_x = 1.0
-    col_1ACBE.scale_y = 1.0
-    col_1ACBE.alignment = 'Expand'.upper()
-    col_1ACBE.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     box_D327E = col_1ACBE.box()
-    box_D327E.alert = False
-    box_D327E.enabled = True
-    box_D327E.active = True
-    box_D327E.use_property_split = False
-    box_D327E.use_property_decorate = False
-    box_D327E.alignment = 'Expand'.upper()
-    box_D327E.scale_x = 1.0
-    box_D327E.scale_y = 1.0
-    if not True: box_D327E.operator_context = "EXEC_DEFAULT"
     box_D327E.label(text='Selection Type', icon_value=0)
     attr_77E08 = '["' + str('Socket_39' + '"]') 
     box_D327E.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_77E08), text='', icon_value=0, emboss=True)
@@ -58,15 +32,6 @@ def sna_selective_adjustment_2_function_interface_4A09B(layout_function, ):
     attr_90794 = '["' + str('Socket_29' + '"]') 
     box_D327E.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_90794), text='Value Threshold', icon_value=0, emboss=True)
     box_424BC = col_1ACBE.box()
-    box_424BC.alert = False
-    box_424BC.enabled = True
-    box_424BC.active = True
-    box_424BC.use_property_split = False
-    box_424BC.use_property_decorate = False
-    box_424BC.alignment = 'Expand'.upper()
-    box_424BC.scale_x = 1.0
-    box_424BC.scale_y = 1.0
-    if not True: box_424BC.operator_context = "EXEC_DEFAULT"
     box_424BC.label(text='Blend Mode', icon_value=0)
     attr_D9EB5 = '["' + str('Socket_41' + '"]') 
     box_424BC.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_D9EB5), text='', icon_value=0, emboss=True)
@@ -75,29 +40,11 @@ def sna_selective_adjustment_2_function_interface_4A09B(layout_function, ):
     attr_4668B = '["' + str('Socket_46' + '"]') 
     box_424BC.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_4668B), text='Randomise Mix', icon_value=0, emboss=True)
     box_E92EC = col_1ACBE.box()
-    box_E92EC.alert = False
-    box_E92EC.enabled = True
-    box_E92EC.active = True
-    box_E92EC.use_property_split = False
-    box_E92EC.use_property_decorate = False
-    box_E92EC.alignment = 'Expand'.upper()
-    box_E92EC.scale_x = 1.0
-    box_E92EC.scale_y = 1.0
-    if not True: box_E92EC.operator_context = "EXEC_DEFAULT"
     box_E92EC.label(text='Masking', icon_value=0)
     attr_4D4AA = '["' + str('Socket_43' + '"]') 
     box_E92EC.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_4D4AA), text='Mask By Object', icon_value=0, emboss=True, toggle=True)
     if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_43']:
         col_25741 = box_E92EC.column(heading='', align=False)
-        col_25741.alert = False
-        col_25741.enabled = True
-        col_25741.active = True
-        col_25741.use_property_split = False
-        col_25741.use_property_decorate = False
-        col_25741.scale_x = 1.0
-        col_25741.scale_y = 1.0
-        col_25741.alignment = 'Expand'.upper()
-        col_25741.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_0F906 = '["' + str('Socket_44' + '"]') 
         col_25741.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_0F906), text='', icon_value=0, emboss=True, toggle=True)
         attr_9AC49 = '["' + str('Socket_45' + '"]') 

--- a/src/selective_adjustment_3_function_interface.py
+++ b/src/selective_adjustment_3_function_interface.py
@@ -10,40 +10,14 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_selective_adjustment_3_function_interface_69C53(layout_function, ):
     col_CF5CE = layout_function.column(heading='', align=False)
-    col_CF5CE.alert = False
-    col_CF5CE.enabled = True
-    col_CF5CE.active = True
-    col_CF5CE.use_property_split = False
-    col_CF5CE.use_property_decorate = False
-    col_CF5CE.scale_x = 1.0
-    col_CF5CE.scale_y = 1.0
-    col_CF5CE.alignment = 'Expand'.upper()
-    col_CF5CE.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_CF5CE.label(text='Selective Adjustment 3', icon_value=0)
     col_CF5CE.separator(factor=1.0)
     attr_2E4D3 = '["' + str('Socket_23' + '"]') 
     col_CF5CE.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_2E4D3), text='Enable Selective Colour 3', icon_value=0, emboss=True, toggle=True)
     col_CF5CE.separator(factor=1.0)
     col_E631B = col_CF5CE.column(heading='', align=False)
-    col_E631B.alert = False
     col_E631B.enabled = bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_23']
-    col_E631B.active = True
-    col_E631B.use_property_split = False
-    col_E631B.use_property_decorate = False
-    col_E631B.scale_x = 1.0
-    col_E631B.scale_y = 1.0
-    col_E631B.alignment = 'Expand'.upper()
-    col_E631B.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     box_2DDC1 = col_E631B.box()
-    box_2DDC1.alert = False
-    box_2DDC1.enabled = True
-    box_2DDC1.active = True
-    box_2DDC1.use_property_split = False
-    box_2DDC1.use_property_decorate = False
-    box_2DDC1.alignment = 'Expand'.upper()
-    box_2DDC1.scale_x = 1.0
-    box_2DDC1.scale_y = 1.0
-    if not True: box_2DDC1.operator_context = "EXEC_DEFAULT"
     box_2DDC1.label(text='Selection Type', icon_value=0)
     attr_C53D8 = '["' + str('Socket_40' + '"]') 
     box_2DDC1.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_C53D8), text='', icon_value=0, emboss=True)
@@ -58,15 +32,6 @@ def sna_selective_adjustment_3_function_interface_69C53(layout_function, ):
     attr_B4B30 = '["' + str('Socket_30' + '"]') 
     box_2DDC1.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_B4B30), text='Value Threshold', icon_value=0, emboss=True)
     box_D5CAB = col_E631B.box()
-    box_D5CAB.alert = False
-    box_D5CAB.enabled = True
-    box_D5CAB.active = True
-    box_D5CAB.use_property_split = False
-    box_D5CAB.use_property_decorate = False
-    box_D5CAB.alignment = 'Expand'.upper()
-    box_D5CAB.scale_x = 1.0
-    box_D5CAB.scale_y = 1.0
-    if not True: box_D5CAB.operator_context = "EXEC_DEFAULT"
     box_D5CAB.label(text='Blend Mode', icon_value=0)
     attr_7153A = '["' + str('Socket_47' + '"]') 
     box_D5CAB.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_7153A), text='', icon_value=0, emboss=True)
@@ -76,28 +41,11 @@ def sna_selective_adjustment_3_function_interface_69C53(layout_function, ):
     box_D5CAB.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_C7965), text='Randomise Mix', icon_value=0, emboss=True)
     box_E6B78 = col_E631B.box()
     box_E6B78.alert = bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_49']
-    box_E6B78.enabled = True
-    box_E6B78.active = True
-    box_E6B78.use_property_split = False
-    box_E6B78.use_property_decorate = False
-    box_E6B78.alignment = 'Expand'.upper()
-    box_E6B78.scale_x = 1.0
-    box_E6B78.scale_y = 1.0
-    if not True: box_E6B78.operator_context = "EXEC_DEFAULT"
     box_E6B78.label(text='Masking', icon_value=0)
     attr_24D06 = '["' + str('Socket_49' + '"]') 
     box_E6B78.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_24D06), text='Mask By Object', icon_value=0, emboss=True, toggle=True)
     if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_49']:
         col_E9291 = box_E6B78.column(heading='', align=False)
-        col_E9291.alert = False
-        col_E9291.enabled = True
-        col_E9291.active = True
-        col_E9291.use_property_split = False
-        col_E9291.use_property_decorate = False
-        col_E9291.scale_x = 1.0
-        col_E9291.scale_y = 1.0
-        col_E9291.alignment = 'Expand'.upper()
-        col_E9291.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_3DC41 = '["' + str('Socket_50' + '"]') 
         col_E9291.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_3DC41), text='', icon_value=0, emboss=True, toggle=True)
         attr_020BD = '["' + str('Socket_51' + '"]') 

--- a/src/start_vertex_painting.py
+++ b/src/start_vertex_painting.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Start_Vertex_Painting_A36E0(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         bpy.context.view_layer.objects.active.data.color_attributes.active_color = bpy.context.view_layer.objects.active.data.color_attributes['KIRI_3DGS_Paint']

--- a/src/stop_interval_updates.py
+++ b/src/stop_interval_updates.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Stop_Interval_Updates_83370(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         bpy.context.scene.sna_dgs_scene_properties.r2_interval_stop = True

--- a/src/store_original_lighting.py
+++ b/src/store_original_lighting.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Store_Original_Lighting_99939(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         sna_relight2_0_save_original_3dgs_color_76EB6()
@@ -27,15 +27,6 @@ class SNA_OT_Dgs_Render_Store_Original_Lighting_99939(bpy.types.Operator):
     def draw(self, context):
         layout = self.layout
         box_44ADA = layout.box()
-        box_44ADA.alert = False
-        box_44ADA.enabled = True
-        box_44ADA.active = True
-        box_44ADA.use_property_split = False
-        box_44ADA.use_property_decorate = False
-        box_44ADA.alignment = 'Expand'.upper()
-        box_44ADA.scale_x = 1.0
-        box_44ADA.scale_y = 1.0
-        if not True: box_44ADA.operator_context = "EXEC_DEFAULT"
         box_44ADA.label(text='Any existing stored base light data will be overwritten', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_44ADA.label(text='The current state will be set as the new base light state', icon_value=0)
         box_44ADA.label(text="This action will not respond to 'undo' commands", icon_value=0)

--- a/src/unbind_from_proxy_mesh.py
+++ b/src/unbind_from_proxy_mesh.py
@@ -15,9 +15,9 @@ class SNA_OT_Dgs_Render_Unbind_From_Proxy_Mesh_7648D(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         bpy.context.view_layer.objects.active.lock_location = (False, False, False)

--- a/src/update_bound_3dgs_from_cache.py
+++ b/src/update_bound_3dgs_from_cache.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Update_Bound_3Dgs_From_Cache_385Ec(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         bpy.context.scene.sna_dgs_scene_properties.rig_interval_stop = False

--- a/src/update_bound_3dgs_from_proxy_mesh.py
+++ b/src/update_bound_3dgs_from_proxy_mesh.py
@@ -17,9 +17,9 @@ class SNA_OT_Dgs_Render_Update_Bound_3Dgs_From_Proxy_Mesh_951A0(bpy.types.Operat
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         if 'proxy_sequence_binding' in bpy.context.view_layer.objects.active:

--- a/src/update_enabled_3dgs_objects.py
+++ b/src/update_enabled_3dgs_objects.py
@@ -16,9 +16,9 @@ class SNA_OT_Dgs_Render_Update_Enabled_3Dgs_Objects_6D7F4(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        if bpy.app.version >= (3, 0, 0) and True:
+        if bpy.app.version >= (3, 0, 0):
             cls.poll_message_set('')
-        return not False
+        return True
 
     def execute(self, context):
         sna_update_camera_single_time_9EF18()

--- a/src/vertex_paint_function_interface.py
+++ b/src/vertex_paint_function_interface.py
@@ -11,79 +11,27 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_vertex_paint_function_interface_BEA3E(layout_function, ):
     if (bpy.context.view_layer.objects.active['3DGS_Mesh_Type'] == 'vert'):
         box_2FB04 = layout_function.box()
-        box_2FB04.alert = True
-        box_2FB04.enabled = True
-        box_2FB04.active = True
-        box_2FB04.use_property_split = False
-        box_2FB04.use_property_decorate = False
-        box_2FB04.alignment = 'Expand'.upper()
-        box_2FB04.scale_x = 1.0
-        box_2FB04.scale_y = 1.0
-        if not True: box_2FB04.operator_context = "EXEC_DEFAULT"
         box_2FB04.label(text='Painting is only available for Face based', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_2FB04.label(text='3DGS objects. You can convert this object', icon_value=0)
         box_2FB04.label(text='from the Ctrl+A menu', icon_value=0)
     col_453E1 = layout_function.column(heading='', align=False)
-    col_453E1.alert = False
     col_453E1.enabled = (not (bpy.context.view_layer.objects.active['3DGS_Mesh_Type'] == 'vert'))
-    col_453E1.active = True
-    col_453E1.use_property_split = False
-    col_453E1.use_property_decorate = False
-    col_453E1.scale_x = 1.0
-    col_453E1.scale_y = 1.0
-    col_453E1.alignment = 'Expand'.upper()
-    col_453E1.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     col_453E1.label(text='Vertex Painting', icon_value=0)
     col_453E1.separator(factor=1.0)
     attr_C4F4C = '["' + str('Socket_55' + '"]') 
     col_453E1.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_C4F4C), text='Enable Vertex Painting', icon_value=0, emboss=True, toggle=True)
     col_453E1.separator(factor=1.0)
     col_86FB7 = col_453E1.column(heading='', align=False)
-    col_86FB7.alert = False
     col_86FB7.enabled = bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_55']
-    col_86FB7.active = True
-    col_86FB7.use_property_split = False
-    col_86FB7.use_property_decorate = False
-    col_86FB7.scale_x = 1.0
-    col_86FB7.scale_y = 1.0
-    col_86FB7.alignment = 'Expand'.upper()
-    col_86FB7.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     box_2E9CF = col_86FB7.box()
-    box_2E9CF.alert = False
-    box_2E9CF.enabled = True
-    box_2E9CF.active = True
-    box_2E9CF.use_property_split = False
-    box_2E9CF.use_property_decorate = False
-    box_2E9CF.alignment = 'Expand'.upper()
-    box_2E9CF.scale_x = 1.0
-    box_2E9CF.scale_y = 1.0
-    if not True: box_2E9CF.operator_context = "EXEC_DEFAULT"
     box_2E9CF.label(text='Painting', icon_value=0)
     if (property_exists("bpy.context.view_layer.objects.active.data.color_attributes", globals(), locals()) and 'KIRI_3DGS_Paint' in bpy.context.view_layer.objects.active.data.color_attributes):
         op = box_2E9CF.operator('sna.dgs_render_start_vertex_painting_a36e0', text='Start Painting', icon_value=0, emboss=True, depress=False)
     else:
         box_ACBF2 = box_2E9CF.box()
-        box_ACBF2.alert = False
-        box_ACBF2.enabled = True
-        box_ACBF2.active = True
-        box_ACBF2.use_property_split = False
-        box_ACBF2.use_property_decorate = False
-        box_ACBF2.alignment = 'Expand'.upper()
-        box_ACBF2.scale_x = 1.0
-        box_ACBF2.scale_y = 1.0
-        if not True: box_ACBF2.operator_context = "EXEC_DEFAULT"
         box_ACBF2.label(text='KIRI_3DGS_Paint attribute is missing', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
     op = box_2E9CF.operator('sna.dgs_render_refresh__create_paint_attribute_84655', text='Reset Paint', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'update.svg')), emboss=True, depress=False)
     box_7E936 = col_86FB7.box()
-    box_7E936.alert = False
-    box_7E936.enabled = True
-    box_7E936.active = True
-    box_7E936.use_property_split = False
-    box_7E936.use_property_decorate = False
-    box_7E936.alignment = 'Expand'.upper()
-    box_7E936.scale_x = 1.0
-    box_7E936.scale_y = 1.0
-    if not True: box_7E936.operator_context = "EXEC_DEFAULT"
     box_7E936.label(text='Blend Mode', icon_value=0)
     attr_97713 = '["' + str('Socket_62' + '"]') 
     box_7E936.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_97713), text='', icon_value=0, emboss=True)
@@ -91,28 +39,11 @@ def sna_vertex_paint_function_interface_BEA3E(layout_function, ):
     box_7E936.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_2A320), text='Mix Factor', icon_value=0, emboss=True)
     box_55BC3 = col_86FB7.box()
     box_55BC3.alert = bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_64']
-    box_55BC3.enabled = True
-    box_55BC3.active = True
-    box_55BC3.use_property_split = False
-    box_55BC3.use_property_decorate = False
-    box_55BC3.alignment = 'Expand'.upper()
-    box_55BC3.scale_x = 1.0
-    box_55BC3.scale_y = 1.0
-    if not True: box_55BC3.operator_context = "EXEC_DEFAULT"
     box_55BC3.label(text='Masking', icon_value=0)
     attr_03413 = '["' + str('Socket_64' + '"]') 
     box_55BC3.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_03413), text='Mask By Object', icon_value=0, emboss=True, toggle=True)
     if bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material']['Socket_64']:
         col_DC970 = box_55BC3.column(heading='', align=False)
-        col_DC970.alert = False
-        col_DC970.enabled = True
-        col_DC970.active = True
-        col_DC970.use_property_split = False
-        col_DC970.use_property_decorate = False
-        col_DC970.scale_x = 1.0
-        col_DC970.scale_y = 1.0
-        col_DC970.alignment = 'Expand'.upper()
-        col_DC970.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         attr_7340F = '["' + str('Socket_65' + '"]') 
         col_DC970.prop(*kiri_geometry_nodes_ui_target(bpy.context.view_layer.objects.active.modifiers['KIRI_3DGS_Adjust_Colour_And_Material'], attr_7340F), text='', icon_value=0, emboss=True, toggle=True)
         attr_34BD5 = '["' + str('Socket_66' + '"]') 

--- a/src/vertex_paint_function_interface.py
+++ b/src/vertex_paint_function_interface.py
@@ -11,6 +11,7 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_vertex_paint_function_interface_BEA3E(layout_function, ):
     if (bpy.context.view_layer.objects.active['3DGS_Mesh_Type'] == 'vert'):
         box_2FB04 = layout_function.box()
+        box_2FB04.alert = True
         box_2FB04.label(text='Painting is only available for Face based', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_2FB04.label(text='3DGS objects. You can convert this object', icon_value=0)
         box_2FB04.label(text='from the Ctrl+A menu', icon_value=0)


### PR DESCRIPTION
## Summary

- Remove constant boolean expressions and unreachable operator-context assignments from the generated UI modules.
- Remove layout assignments that match Blender's defaults while preserving dynamic UI state and functional calls.
- Fixes #74

## Testing

- Blender version: Not available in this environment.
- OS: Windows
- Flows tested:
  - `python -m compileall -q src __init__.py`
  - Static scan confirmed the targeted generated no-op patterns are absent.
  - `git diff --check`

## Screenshots / recordings

No screenshots: this refactor is intended to preserve the rendered UI and behavior.

## Checklist

- [ ] I tested this manually on Blender 5.2 (primary target).
- [x] The PR contains one logical change (no unrelated fixes bundled in).
- [x] "Allow edits from maintainers" is enabled on this PR.
- [x] PR body describes what changed and why in enough detail for a future reader to understand without opening the diff.