### PR TITLE
Remove no-op layout assignments from Light Bake UI

### DIFF
--- a/src/light_bake.py
+++ b/src/light_bake.py
@@ -12,86 +12,25 @@ __package__ = __package__.rsplit('.', 1)[0]
 def sna_light_bake_8F346(layout_function, ):
     if (bpy.context.preferences.addons[__package__].preferences.sna_cache_file_directory == ''):
         box_923B8 = layout_function.box()
-        box_923B8.alert = False
-        box_923B8.enabled = True
-        box_923B8.active = True
-        box_923B8.use_property_split = False
-        box_923B8.use_property_decorate = False
-        box_923B8.alignment = 'Expand'.upper()
-        box_923B8.scale_x = 1.0
-        box_923B8.scale_y = 1.0
-        if not True: box_923B8.operator_context = "EXEC_DEFAULT"
         box_923B8.label(text='Cache directory is empty.', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
         box_923B8.label(text='Set it in Preferences', icon_value=0)
     col_3F618 = layout_function.column(heading='', align=True)
-    col_3F618.alert = False
     col_3F618.enabled = (bpy.context.preferences.addons[__package__].preferences.sna_cache_file_directory != '')
-    col_3F618.active = True
-    col_3F618.use_property_split = False
-    col_3F618.use_property_decorate = False
-    col_3F618.scale_x = 1.0
-    col_3F618.scale_y = 1.0
-    col_3F618.alignment = 'Expand'.upper()
-    col_3F618.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     if (bpy.context.view_layer.objects.active == None):
         box_C7AE0 = col_3F618.box()
-        box_C7AE0.alert = False
-        box_C7AE0.enabled = True
-        box_C7AE0.active = True
-        box_C7AE0.use_property_split = False
-        box_C7AE0.use_property_decorate = False
-        box_C7AE0.alignment = 'Expand'.upper()
-        box_C7AE0.scale_x = 1.0
         box_C7AE0.scale_y = 2.0
-        if not True: box_C7AE0.operator_context = "EXEC_DEFAULT"
         box_C7AE0.label(text='No Active Object', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
     else:
         if '3DGS_Mesh_Type' in bpy.context.view_layer.objects.active:
             col_9A00F = col_3F618.column(heading='', align=False)
-            col_9A00F.alert = False
-            col_9A00F.enabled = True
-            col_9A00F.active = True
-            col_9A00F.use_property_split = False
-            col_9A00F.use_property_decorate = False
-            col_9A00F.scale_x = 1.0
-            col_9A00F.scale_y = 1.0
-            col_9A00F.alignment = 'Expand'.upper()
-            col_9A00F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             box_18E8E = col_9A00F.box()
-            box_18E8E.alert = False
-            box_18E8E.enabled = True
-            box_18E8E.active = True
-            box_18E8E.use_property_split = False
-            box_18E8E.use_property_decorate = False
-            box_18E8E.alignment = 'Expand'.upper()
-            box_18E8E.scale_x = 1.0
-            box_18E8E.scale_y = 1.0
-            if not True: box_18E8E.operator_context = "EXEC_DEFAULT"
             box_18E8E.label(text='Proxy Mesh', icon_value=0)
             row_33E8E = box_18E8E.row(heading='', align=True)
-            row_33E8E.alert = False
-            row_33E8E.enabled = True
-            row_33E8E.active = True
-            row_33E8E.use_property_split = False
-            row_33E8E.use_property_decorate = False
-            row_33E8E.scale_x = 1.0
-            row_33E8E.scale_y = 1.0
-            row_33E8E.alignment = 'Expand'.upper()
-            row_33E8E.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
             row_33E8E.prop(bpy.context.view_layer.objects.active.sna_dgs_object_properties, 'rig_proxy_mesh', text='', icon_value=0, emboss=True)
             if (bpy.context.view_layer.objects.active.sna_dgs_object_properties.rig_proxy_mesh == None):
                 pass
             else:
                 row_BD7EE = row_33E8E.row(heading='', align=True)
-                row_BD7EE.alert = False
-                row_BD7EE.enabled = True
-                row_BD7EE.active = True
-                row_BD7EE.use_property_split = False
-                row_BD7EE.use_property_decorate = False
-                row_BD7EE.scale_x = 1.0
-                row_BD7EE.scale_y = 1.0
-                row_BD7EE.alignment = 'Expand'.upper()
-                row_BD7EE.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 op = row_BD7EE.operator('sna.dgs_render_select_object_b1f49', text='', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'mouse-pointer.svg')), emboss=True, depress=False)
                 op.sna_object_name = bpy.context.view_layer.objects.active.sna_dgs_object_properties.rig_proxy_mesh.name
                 row_BD7EE.prop(bpy.context.view_layer.objects.active.sna_dgs_object_properties.rig_proxy_mesh, 'hide_viewport', text='', icon_value=0, emboss=True)
@@ -101,60 +40,18 @@ def sna_light_bake_8F346(layout_function, ):
             else:
                 col_9A00F.separator(factor=3.0)
                 col_DA035 = col_9A00F.column(heading='', align=False)
-                col_DA035.alert = False
-                col_DA035.enabled = True
-                col_DA035.active = True
-                col_DA035.use_property_split = False
-                col_DA035.use_property_decorate = False
-                col_DA035.scale_x = 1.0
-                col_DA035.scale_y = 1.0
-                col_DA035.alignment = 'Expand'.upper()
-                col_DA035.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 row_18A3E = col_DA035.row(heading='', align=False)
-                row_18A3E.alert = False
-                row_18A3E.enabled = True
-                row_18A3E.active = True
-                row_18A3E.use_property_split = False
-                row_18A3E.use_property_decorate = False
-                row_18A3E.scale_x = 1.0
                 row_18A3E.scale_y = 2.0
-                row_18A3E.alignment = 'Expand'.upper()
-                row_18A3E.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 row_18A3E.prop(bpy.context.scene.sna_dgs_scene_properties, 'light_bake_active_menu', text=bpy.context.scene.sna_dgs_scene_properties.light_bake_active_menu, icon_value=0, emboss=True, expand=True)
                 if bpy.context.scene.sna_dgs_scene_properties.light_bake_active_menu == "1. Store Light":
                     col_56E5A = col_DA035.column(heading='', align=False)
                     col_56E5A.alert = True
-                    col_56E5A.enabled = True
-                    col_56E5A.active = True
-                    col_56E5A.use_property_split = False
-                    col_56E5A.use_property_decorate = False
-                    col_56E5A.scale_x = 1.0
-                    col_56E5A.scale_y = 1.0
-                    col_56E5A.alignment = 'Expand'.upper()
-                    col_56E5A.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                     if 'proxy_deferred_relight_stage_saved' in bpy.context.view_layer.objects.active:
                         if bpy.context.view_layer.objects.active['proxy_deferred_relight_stage_saved']:
                             box_D56BA = col_56E5A.box()
-                            box_D56BA.alert = False
-                            box_D56BA.enabled = True
-                            box_D56BA.active = True
-                            box_D56BA.use_property_split = False
-                            box_D56BA.use_property_decorate = False
-                            box_D56BA.alignment = 'Expand'.upper()
-                            box_D56BA.scale_x = 1.0
-                            box_D56BA.scale_y = 1.0
-                            if not True: box_D56BA.operator_context = "EXEC_DEFAULT"
                             box_D56BA.label(text='Light data has previously been saved', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
                     col_305D8 = col_56E5A.column(heading='', align=False)
-                    col_305D8.alert = False
-                    col_305D8.enabled = True
-                    col_305D8.active = True
-                    col_305D8.use_property_split = False
-                    col_305D8.use_property_decorate = False
-                    col_305D8.scale_x = 1.0
                     col_305D8.scale_y = 2.0
-                    col_305D8.alignment = 'Expand'.upper()
-                    col_305D8.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                     op = col_305D8.operator('sna.dgs_render_store_original_lighting_99939', text='Store Original Lighting', icon_value=0, emboss=True, depress=False)
                 elif bpy.context.scene.sna_dgs_scene_properties.light_bake_active_menu == "2. Bake Light":
                     layout_function = col_DA035
@@ -165,35 +62,10 @@ def sna_light_bake_8F346(layout_function, ):
                 else:
                     pass
                 box_82787 = col_DA035.box()
-                box_82787.alert = False
-                box_82787.enabled = True
-                box_82787.active = True
-                box_82787.use_property_split = False
-                box_82787.use_property_decorate = False
-                box_82787.alignment = 'Expand'.upper()
-                box_82787.scale_x = 1.0
-                box_82787.scale_y = 1.0
-                if not True: box_82787.operator_context = "EXEC_DEFAULT"
                 col_9B44F = box_82787.column(heading='', align=False)
                 col_9B44F.alert = True
-                col_9B44F.enabled = True
-                col_9B44F.active = True
-                col_9B44F.use_property_split = False
-                col_9B44F.use_property_decorate = False
-                col_9B44F.scale_x = 1.0
-                col_9B44F.scale_y = 1.0
-                col_9B44F.alignment = 'Expand'.upper()
-                col_9B44F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 op = col_9B44F.operator('sna.dgs_render_restore_original_light_9a7fe', text='Restore Lighting', icon_value=0, emboss=True, depress=False)
         else:
             box_B787A = col_3F618.box()
-            box_B787A.alert = False
-            box_B787A.enabled = True
-            box_B787A.active = True
-            box_B787A.use_property_split = False
-            box_B787A.use_property_decorate = False
-            box_B787A.alignment = 'Expand'.upper()
-            box_B787A.scale_x = 1.0
             box_B787A.scale_y = 2.0
-            if not True: box_B787A.operator_context = "EXEC_DEFAULT"
             box_B787A.label(text='The Active Object is not a 3DGS Mesh', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))

--- a/src/light_bake_apply.py
+++ b/src/light_bake_apply.py
@@ -13,192 +13,49 @@ def sna_light_bake_apply_A5653(layout_function, ):
             pass
         else:
             box_FAC0D = layout_function.box()
-            box_FAC0D.alert = False
-            box_FAC0D.enabled = True
-            box_FAC0D.active = True
-            box_FAC0D.use_property_split = False
-            box_FAC0D.use_property_decorate = False
-            box_FAC0D.alignment = 'Expand'.upper()
-            box_FAC0D.scale_x = 1.0
-            box_FAC0D.scale_y = 1.0
-            if not True: box_FAC0D.operator_context = "EXEC_DEFAULT"
             box_FAC0D.label(text='Bake light data before applying', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
     else:
         box_C3353 = layout_function.box()
-        box_C3353.alert = False
-        box_C3353.enabled = True
-        box_C3353.active = True
-        box_C3353.use_property_split = False
-        box_C3353.use_property_decorate = False
-        box_C3353.alignment = 'Expand'.upper()
-        box_C3353.scale_x = 1.0
-        box_C3353.scale_y = 1.0
-        if not True: box_C3353.operator_context = "EXEC_DEFAULT"
         box_C3353.label(text='Bake light data before applying', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'warning.svg')))
     box_FCA92 = layout_function.box()
-    box_FCA92.alert = False
-    box_FCA92.enabled = True
-    box_FCA92.active = True
-    box_FCA92.use_property_split = False
-    box_FCA92.use_property_decorate = False
-    box_FCA92.alignment = 'Expand'.upper()
-    box_FCA92.scale_x = 1.0
-    box_FCA92.scale_y = 1.0
-    if not True: box_FCA92.operator_context = "EXEC_DEFAULT"
     box_FCA92.label(text='Light Pass Mix', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
     col_55C97 = box_FCA92.column(heading='', align=True)
-    col_55C97.alert = False
-    col_55C97.enabled = True
-    col_55C97.active = True
-    col_55C97.use_property_split = False
-    col_55C97.use_property_decorate = False
-    col_55C97.scale_x = 1.0
-    col_55C97.scale_y = 1.0
-    col_55C97.alignment = 'Expand'.upper()
-    col_55C97.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
     col_55C97.prop(bpy.context.scene.sna_dgs_scene_properties, 'indirect_strength', text='Indirect Strength', icon_value=0, emboss=True)
     col_55C97.prop(bpy.context.scene.sna_dgs_scene_properties, 'direct_strength', text='Direct Strength', icon_value=0, emboss=True)
     col_55C97.prop(bpy.context.scene.sna_dgs_scene_properties, 'occlusion_strength', text='Occlusion Strength', icon_value=0, emboss=True)
     col_55C97.prop(bpy.context.scene.sna_dgs_scene_properties, 'shadow_strength', text='Shadow Strength', icon_value=0, emboss=True)
     if (bpy.context.scene.sna_dgs_scene_properties.relight_include_world_environment or bpy.context.scene.sna_dgs_scene_properties.relight_include_scene_lights):
         col_2D53F = layout_function.column(heading='', align=True)
-        col_2D53F.alert = False
-        col_2D53F.enabled = True
-        col_2D53F.active = True
-        col_2D53F.use_property_split = False
-        col_2D53F.use_property_decorate = False
-        col_2D53F.scale_x = 1.0
-        col_2D53F.scale_y = 1.0
-        col_2D53F.alignment = 'Expand'.upper()
-        col_2D53F.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         box_C2FE8 = col_2D53F.box()
-        box_C2FE8.alert = False
-        box_C2FE8.enabled = True
-        box_C2FE8.active = True
-        box_C2FE8.use_property_split = False
-        box_C2FE8.use_property_decorate = False
-        box_C2FE8.alignment = 'Expand'.upper()
-        box_C2FE8.scale_x = 1.0
-        box_C2FE8.scale_y = 1.0
-        if not True: box_C2FE8.operator_context = "EXEC_DEFAULT"
         col_A17CD = box_C2FE8.column(heading='', align=True)
-        col_A17CD.alert = False
-        col_A17CD.enabled = True
-        col_A17CD.active = True
-        col_A17CD.use_property_split = False
-        col_A17CD.use_property_decorate = False
-        col_A17CD.scale_x = 1.0
-        col_A17CD.scale_y = 1.0
-        col_A17CD.alignment = 'Expand'.upper()
-        col_A17CD.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
         col_A17CD.label(text='Color Mix', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
         split_C326C = col_A17CD.split(factor=0.5, align=False)
-        split_C326C.alert = False
-        split_C326C.enabled = True
-        split_C326C.active = True
-        split_C326C.use_property_split = False
-        split_C326C.use_property_decorate = False
-        split_C326C.scale_x = 1.0
-        split_C326C.scale_y = 1.0
-        split_C326C.alignment = 'Expand'.upper()
-        if not True: split_C326C.operator_context = "EXEC_DEFAULT"
         split_C326C.label(text='Factor Curve', icon_value=0)
         split_C326C.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_factor_curve_mode', text='', icon_value=0, emboss=True)
         split_AB173 = col_A17CD.split(factor=0.5, align=False)
-        split_AB173.alert = False
-        split_AB173.enabled = True
-        split_AB173.active = True
-        split_AB173.use_property_split = False
-        split_AB173.use_property_decorate = False
-        split_AB173.scale_x = 1.0
-        split_AB173.scale_y = 1.0
-        split_AB173.alignment = 'Expand'.upper()
-        if not True: split_AB173.operator_context = "EXEC_DEFAULT"
         split_AB173.label(text='Factor Mode', icon_value=0)
         split_AB173.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_lighting_factor_mode', text='', icon_value=0, emboss=True)
         if (bpy.context.scene.sna_dgs_scene_properties.relight_lighting_factor_mode == 'Luminance'):
             pass
         else:
             col_D67D0 = col_A17CD.column(heading='', align=True)
-            col_D67D0.alert = False
-            col_D67D0.enabled = True
-            col_D67D0.active = True
-            col_D67D0.use_property_split = False
-            col_D67D0.use_property_decorate = False
-            col_D67D0.scale_x = 1.0
-            col_D67D0.scale_y = 1.0
-            col_D67D0.alignment = 'Expand'.upper()
-            col_D67D0.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
             col_D67D0.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_colorize_mix', text='Color Mix', icon_value=0, emboss=True)
             split_18C65 = col_D67D0.split(factor=0.4000000059604645, align=True)
-            split_18C65.alert = False
-            split_18C65.enabled = True
-            split_18C65.active = True
-            split_18C65.use_property_split = False
-            split_18C65.use_property_decorate = False
-            split_18C65.scale_x = 1.0
-            split_18C65.scale_y = 1.0
-            split_18C65.alignment = 'Expand'.upper()
-            if not True: split_18C65.operator_context = "EXEC_DEFAULT"
             split_18C65.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_max_color_tint', text='Max Tint', icon_value=0, emboss=True)
             split_18C65.prop(bpy.context.scene.sna_dgs_scene_properties, 'max_color_tint_mode', text='', icon_value=0, emboss=True)
         box_85BFD = col_2D53F.box()
-        box_85BFD.alert = False
-        box_85BFD.enabled = True
-        box_85BFD.active = True
-        box_85BFD.use_property_split = False
-        box_85BFD.use_property_decorate = False
-        box_85BFD.alignment = 'Expand'.upper()
-        box_85BFD.scale_x = 1.0
-        box_85BFD.scale_y = 1.0
-        if not True: box_85BFD.operator_context = "EXEC_DEFAULT"
         box_85BFD.label(text='Global Strength', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
         col_B19E2 = box_85BFD.column(heading='', align=True)
-        col_B19E2.alert = False
-        col_B19E2.enabled = True
-        col_B19E2.active = True
-        col_B19E2.use_property_split = False
-        col_B19E2.use_property_decorate = False
-        col_B19E2.scale_x = 1.0
-        col_B19E2.scale_y = 1.0
-        col_B19E2.alignment = 'Expand'.upper()
-        col_B19E2.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
         col_B19E2.prop(bpy.context.scene.sna_dgs_scene_properties, 'ambient_floor', text='Ambient Base', icon_value=0, emboss=True)
         col_B19E2.prop(bpy.context.scene.sna_dgs_scene_properties, 'light_gain', text='Light Gain', icon_value=0, emboss=True)
         col_B19E2.prop(bpy.context.scene.sna_dgs_scene_properties, 'light_power', text='Light Contrast', icon_value=0, emboss=True)
         col_B19E2.prop(bpy.context.scene.sna_dgs_scene_properties, 'max_light_factor', text='Max Light Factor', icon_value=0, emboss=True)
         box_51F49 = col_2D53F.box()
-        box_51F49.alert = False
-        box_51F49.enabled = True
-        box_51F49.active = True
-        box_51F49.use_property_split = False
-        box_51F49.use_property_decorate = False
-        box_51F49.alignment = 'Expand'.upper()
-        box_51F49.scale_x = 1.0
-        box_51F49.scale_y = 1.0
-        if not True: box_51F49.operator_context = "EXEC_DEFAULT"
         box_51F49.label(text='SH Updates', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
         col_57EA1 = box_51F49.column(heading='', align=True)
-        col_57EA1.alert = False
-        col_57EA1.enabled = True
-        col_57EA1.active = True
-        col_57EA1.use_property_split = False
-        col_57EA1.use_property_decorate = False
-        col_57EA1.scale_x = 1.0
-        col_57EA1.scale_y = 1.0
-        col_57EA1.alignment = 'Expand'.upper()
-        col_57EA1.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         col_57EA1.prop(bpy.context.scene.sna_dgs_scene_properties, 'export_mode', text='', icon_value=0, emboss=True)
         if (bpy.context.scene.sna_dgs_scene_properties.export_mode == 'Dampen Original SH'):
             col_57EA1.prop(bpy.context.scene.sna_dgs_scene_properties, 'directionality_strength', text='SH Strength', icon_value=0, emboss=True)
         box_BBA23 = col_2D53F.box()
-        box_BBA23.alert = False
-        box_BBA23.enabled = True
-        box_BBA23.active = True
-        box_BBA23.use_property_split = False
-        box_BBA23.use_property_decorate = False
-        box_BBA23.alignment = 'Expand'.upper()
-        box_BBA23.scale_x = 1.0
         box_BBA23.scale_y = 2.0
-        if not True: box_BBA23.operator_context = "EXEC_DEFAULT"
         op = box_BBA23.operator('sna.dgs_render_apply_light_data_6c5ad', text='Apply Lighting', icon_value=0, emboss=True, depress=False)

--- a/src/light_bake_build.py
+++ b/src/light_bake_build.py
@@ -9,73 +9,19 @@ __package__ = __package__.rsplit('.', 1)[0]
 
 def sna_light_bake_build_8B9DD(layout_function, ):
     box_90A4F = layout_function.box()
-    box_90A4F.alert = False
-    box_90A4F.enabled = True
-    box_90A4F.active = True
-    box_90A4F.use_property_split = False
-    box_90A4F.use_property_decorate = False
-    box_90A4F.alignment = 'Expand'.upper()
-    box_90A4F.scale_x = 1.0
-    box_90A4F.scale_y = 1.0
-    if not True: box_90A4F.operator_context = "EXEC_DEFAULT"
     box_90A4F.label(text='Include', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
     row_095CC = box_90A4F.row(heading='', align=False)
-    row_095CC.alert = False
-    row_095CC.enabled = True
-    row_095CC.active = True
-    row_095CC.use_property_split = False
-    row_095CC.use_property_decorate = False
-    row_095CC.scale_x = 1.0
-    row_095CC.scale_y = 1.0
-    row_095CC.alignment = 'Expand'.upper()
-    row_095CC.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
     row_095CC.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_include_world_environment', text='World', icon_value=0, emboss=True)
     row_095CC.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_include_scene_lights', text='Light Objects', icon_value=0, emboss=True)
     if (bpy.context.scene.sna_dgs_scene_properties.relight_include_world_environment or bpy.context.scene.sna_dgs_scene_properties.relight_include_scene_lights):
         col_AD78B = layout_function.column(heading='', align=True)
-        col_AD78B.alert = False
-        col_AD78B.enabled = True
-        col_AD78B.active = True
-        col_AD78B.use_property_split = False
-        col_AD78B.use_property_decorate = False
-        col_AD78B.scale_x = 1.0
-        col_AD78B.scale_y = 1.0
-        col_AD78B.alignment = 'Expand'.upper()
-        col_AD78B.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
         box_4882E = col_AD78B.box()
-        box_4882E.alert = False
-        box_4882E.enabled = True
-        box_4882E.active = True
-        box_4882E.use_property_split = False
-        box_4882E.use_property_decorate = False
-        box_4882E.alignment = 'Expand'.upper()
-        box_4882E.scale_x = 1.0
-        box_4882E.scale_y = 1.0
-        if not True: box_4882E.operator_context = "EXEC_DEFAULT"
         col_3E710 = box_4882E.column(heading='', align=True)
-        col_3E710.alert = False
-        col_3E710.enabled = True
-        col_3E710.active = True
-        col_3E710.use_property_split = False
-        col_3E710.use_property_decorate = False
-        col_3E710.scale_x = 1.0
-        col_3E710.scale_y = 1.0
-        col_3E710.alignment = 'Expand'.upper()
-        col_3E710.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
         col_3E710.label(text='Interpolation', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
         col_3E710.prop(bpy.context.scene.sna_dgs_scene_properties, 'normal_smoothing', text='Proxy Normal Smoothing', icon_value=0, emboss=True)
         col_3E710.prop(bpy.context.scene.sna_dgs_scene_properties, 'pre_light_smoothing', text='Pre-Light Smoothing', icon_value=0, emboss=True)
         col_3E710.prop(bpy.context.scene.sna_dgs_scene_properties, 'post_light_smoothing', text='Post-Light Smoothing', icon_value=0, emboss=True)
         split_755B4 = col_3E710.split(factor=0.5, align=False)
-        split_755B4.alert = False
-        split_755B4.enabled = True
-        split_755B4.active = True
-        split_755B4.use_property_split = False
-        split_755B4.use_property_decorate = False
-        split_755B4.scale_x = 1.0
-        split_755B4.scale_y = 1.0
-        split_755B4.alignment = 'Expand'.upper()
-        if not True: split_755B4.operator_context = "EXEC_DEFAULT"
         split_755B4.label(text='Transfer Style', icon_value=0)
         split_755B4.prop(bpy.context.scene.sna_dgs_scene_properties, 'transfer_style', text='', icon_value=0, emboss=True)
         if (bpy.context.scene.sna_dgs_scene_properties.transfer_style == 'Accurate'):
@@ -84,25 +30,7 @@ def sna_light_bake_build_8B9DD(layout_function, ):
             col_3E710.prop(bpy.context.scene.sna_dgs_scene_properties, 'transfer_smoothness', text='Transfer Smoothness', icon_value=0, emboss=True)
         if bpy.context.scene.sna_dgs_scene_properties.relight_include_world_environment:
             box_018E2 = col_AD78B.box()
-            box_018E2.alert = False
-            box_018E2.enabled = True
-            box_018E2.active = True
-            box_018E2.use_property_split = False
-            box_018E2.use_property_decorate = False
-            box_018E2.alignment = 'Expand'.upper()
-            box_018E2.scale_x = 1.0
-            box_018E2.scale_y = 1.0
-            if not True: box_018E2.operator_context = "EXEC_DEFAULT"
             col_12C25 = box_018E2.column(heading='', align=True)
-            col_12C25.alert = False
-            col_12C25.enabled = True
-            col_12C25.active = True
-            col_12C25.use_property_split = False
-            col_12C25.use_property_decorate = False
-            col_12C25.scale_x = 1.0
-            col_12C25.scale_y = 1.0
-            col_12C25.alignment = 'Expand'.upper()
-            col_12C25.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
             col_12C25.label(text='World Light', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
             col_12C25.prop(bpy.context.scene.sna_dgs_scene_properties, 'hdri_max_width', text='HDRI Max Width', icon_value=0, emboss=True)
             col_12C25.prop(bpy.context.scene.sna_dgs_scene_properties, 'irradiance_resolution', text='Irradiance Resolution', icon_value=0, emboss=True)
@@ -110,65 +38,21 @@ def sna_light_bake_build_8B9DD(layout_function, ):
             col_12C25.prop(bpy.context.scene.sna_dgs_scene_properties, 'irradiance_luminance_clamp', text='Irradiance Clamp', icon_value=0, emboss=True)
         if bpy.context.scene.sna_dgs_scene_properties.relight_include_world_environment:
             box_10AE9 = col_AD78B.box()
-            box_10AE9.alert = False
-            box_10AE9.enabled = True
-            box_10AE9.active = True
-            box_10AE9.use_property_split = False
-            box_10AE9.use_property_decorate = False
-            box_10AE9.alignment = 'Expand'.upper()
-            box_10AE9.scale_x = 1.0
-            box_10AE9.scale_y = 1.0
-            if not True: box_10AE9.operator_context = "EXEC_DEFAULT"
             box_10AE9.label(text='World Occlusion', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
             box_10AE9.prop(bpy.context.scene.sna_dgs_scene_properties, 'use_proxy_occlusion', text='Enable Proxy Occlusion', icon_value=0, emboss=True)
             if bpy.context.scene.sna_dgs_scene_properties.use_proxy_occlusion:
                 col_803AA = box_10AE9.column(heading='', align=True)
-                col_803AA.alert = False
-                col_803AA.enabled = True
-                col_803AA.active = True
-                col_803AA.use_property_split = False
-                col_803AA.use_property_decorate = False
-                col_803AA.scale_x = 1.0
-                col_803AA.scale_y = 1.0
-                col_803AA.alignment = 'Expand'.upper()
-                col_803AA.operator_context = "INVOKE_DEFAULT" if True else "EXEC_DEFAULT"
                 col_803AA.prop(bpy.context.scene.sna_dgs_scene_properties, 'occlusion_sample_count', text='Occlusion sample count', icon_value=0, emboss=True)
                 col_803AA.prop(bpy.context.scene.sna_dgs_scene_properties, 'occlusion_bias', text='Occlusion bias', icon_value=0, emboss=True)
                 col_803AA.prop(bpy.context.scene.sna_dgs_scene_properties, 'occlusion_max_distance', text='Occlusion Max Distance', icon_value=0, emboss=True)
         if bpy.context.scene.sna_dgs_scene_properties.relight_include_scene_lights:
             box_8F86C = col_AD78B.box()
-            box_8F86C.alert = False
-            box_8F86C.enabled = True
-            box_8F86C.active = True
-            box_8F86C.use_property_split = False
-            box_8F86C.use_property_decorate = False
-            box_8F86C.alignment = 'Expand'.upper()
-            box_8F86C.scale_x = 1.0
-            box_8F86C.scale_y = 1.0
-            if not True: box_8F86C.operator_context = "EXEC_DEFAULT"
             col_548B3 = box_8F86C.column(heading='', align=True)
-            col_548B3.alert = False
-            col_548B3.enabled = True
-            col_548B3.active = True
-            col_548B3.use_property_split = False
-            col_548B3.use_property_decorate = False
-            col_548B3.scale_x = 1.0
-            col_548B3.scale_y = 1.0
-            col_548B3.alignment = 'Expand'.upper()
-            col_548B3.operator_context = "INVOKE_DEFAULT" if False else "EXEC_DEFAULT"
             col_548B3.label(text='Light Objects', icon_value=load_preview_icon(os.path.join(os.path.dirname(__file__), 'assets', 'pointer-right-fill.svg')))
             col_548B3.prop(bpy.context.scene.sna_dgs_scene_properties, 'include_hidden_lights', text='Include Hidden Lights', icon_value=0, emboss=True)
             col_548B3.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_scene_light_gain', text='Light Gain', icon_value=0, emboss=True)
             col_548B3.prop(bpy.context.scene.sna_dgs_scene_properties, 'relight_use_light_shadows', text='Light Object Shadows', icon_value=0, emboss=True)
             col_548B3.prop(bpy.context.scene.sna_dgs_scene_properties, 'light_shadow_bias', text='Light Object Shadow Bias', icon_value=0, emboss=True)
         box_A44FD = col_AD78B.box()
-        box_A44FD.alert = False
-        box_A44FD.enabled = True
-        box_A44FD.active = True
-        box_A44FD.use_property_split = False
-        box_A44FD.use_property_decorate = False
-        box_A44FD.alignment = 'Expand'.upper()
-        box_A44FD.scale_x = 1.0
         box_A44FD.scale_y = 2.0
-        if not True: box_A44FD.operator_context = "EXEC_DEFAULT"
         op = box_A44FD.operator('sna.dgs_render_build_light_data_ab375', text='Bake Light Data', icon_value=0, emboss=True, depress=False)


### PR DESCRIPTION
## Summary

Remove generator-emitted constant layout assignments from the Light Bake UI modules:
- `src/light_bake.py`
- `src/light_bake_apply.py`
- `src/light_bake_build.py`

Only assignments whose values were constant defaults are removed. Existing alert states and functional layout properties remain unchanged.

## Testing

- `python -m compileall -q src __init__.py`
- `git diff --check`
- Blender 5.2.1 LTS headless add-on register/unregister smoke test
- Verified no remaining constant operator-context or boolean no-op patterns in the three changed modules

This focused PR supersedes the Light Bake portion of #78.